### PR TITLE
fix: prevent unexpected logouts on transient errors

### DIFF
--- a/prototype/backend/src/middleware/auth.ts
+++ b/prototype/backend/src/middleware/auth.ts
@@ -25,7 +25,10 @@ export const authenticateToken = (
 
   jwt.verify(token, JWT_SECRET, (err, decoded) => {
     if (err) {
-      return res.status(403).json({ error: 'Invalid or expired token' });
+      // Use 401 for expired/invalid tokens so the frontend interceptor can
+      // detect auth failures consistently and redirect to login.
+      // 403 is reserved for authorization failures (e.g. "not admin").
+      return res.status(401).json({ error: 'Invalid or expired token' });
     }
 
     const payload = decoded as { userId: string | number; username: string; role: string };

--- a/prototype/frontend/src/contexts/AuthContext.tsx
+++ b/prototype/frontend/src/contexts/AuthContext.tsx
@@ -128,11 +128,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const response = await apiClient.get('/api/user/profile');
       setUser(response.data);
     } catch (error) {
-      console.error('Failed to fetch user profile:', error);
-      // If the profile fetch fails (expired/invalid token, server error),
-      // clear auth state so the user is redirected to the login page
-      // rather than stuck in a broken authenticated state.
-      logout();
+      // Only logout on definitive auth failures (401/403). Network errors,
+      // timeouts, and server errors (5xx) should NOT destroy the session —
+      // the token may still be valid and the user can retry.
+      if (isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 403)) {
+        console.error('Auth token rejected, logging out:', error);
+        logout();
+      } else {
+        console.warn('Failed to fetch user profile (keeping session):', error);
+      }
     } finally {
       setLoading(false);
     }

--- a/prototype/frontend/src/utils/apiClient.ts
+++ b/prototype/frontend/src/utils/apiClient.ts
@@ -14,15 +14,20 @@ apiClient.interceptors.request.use((config) => {
   return config;
 });
 
-// Response interceptor: handle 401 for authenticated routes only.
+// Response interceptor: handle auth failures for authenticated routes only.
 // Auth endpoints (login/register) return 401 for invalid credentials,
 // which should be handled by the calling component, not by a redirect.
+// Network errors (no response) are NOT treated as auth failures.
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     const url = error.config?.url || '';
     const isAuthRoute = url.includes('/api/auth/');
-    if (error.response?.status === 401 && !isAuthRoute) {
+    const status = error.response?.status;
+
+    // Only clear token and redirect on definitive auth failures (401/403)
+    // from non-auth routes. Network errors (no response) should not trigger logout.
+    if ((status === 401 || status === 403) && !isAuthRoute) {
       localStorage.removeItem('token');
       window.location.href = '/login';
     }


### PR DESCRIPTION
- Change auth middleware to return 401 (not 403) for expired/invalid tokens
- Frontend interceptor now catches both 401 and 403 for consistent redirect
- refreshUser() only logs out on auth failures, not network errors/timeouts

Fixes issue where Android Chrome and Windows Chrome users were being logged out due to transient network failures triggering session cleanup.