### PR TITLE
fix: remove test file from tsconfig include to fix build

### DIFF
--- a/prototype/backend/tsconfig.json
+++ b/prototype/backend/tsconfig.json
@@ -13,5 +13,5 @@
     "moduleResolution": "node"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
The test file tests/guide/content-validation.test.ts was included in tsconfig.json but falls outside rootDir (src/), causing TS6059 build errors. Test files are handled by Jest and don't belong in the production build config.