### PR TITLE
fix: copy guide content files to dist on build

### DIFF
--- a/prototype/backend/package.json
+++ b/prototype/backend/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc && tsc --project tsconfig.seed.json",
+    "build": "tsc && tsc --project tsconfig.seed.json && cp -r src/content dist/content",
     "start": "node dist/index.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",


### PR DESCRIPTION
tsc only emits .js files, so the markdown articles and sections.json in src/content/guide/ were missing from dist/ at runtime. The guide service resolves its content directory relative to __dirname (dist/), causing empty responses on deployed environments.