### PR TITLE
fix: prevent false logouts on navigation and proxy/WAF blocks

### DIFF
--- a/prototype/frontend/src/contexts/AuthContext.tsx
+++ b/prototype/frontend/src/contexts/AuthContext.tsx
@@ -128,12 +128,20 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const response = await apiClient.get('/api/user/profile');
       setUser(response.data);
     } catch (error) {
-      // Only logout on definitive auth failures (401/403). Network errors,
-      // timeouts, and server errors (5xx) should NOT destroy the session —
-      // the token may still be valid and the user can retry.
+      // Only logout on definitive auth failures from our own backend.
+      // Proxy/WAF/DDoS layers may return 401/403 with non-JSON bodies —
+      // those should NOT destroy the session since the token may still be valid.
       if (isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 403)) {
-        console.error('Auth token rejected, logging out:', error);
-        logout();
+        const data = error.response?.data;
+        const isBackendAuthError =
+          data && typeof data === 'object' && typeof data.error === 'string';
+
+        if (isBackendAuthError) {
+          console.error('Auth token rejected by backend, logging out:', error);
+          logout();
+        } else {
+          console.warn('Non-backend 401/403 during profile fetch (possible proxy/WAF block), keeping session:', error);
+        }
       } else {
         console.warn('Failed to fetch user profile (keeping session):', error);
       }

--- a/prototype/frontend/src/pages/FrontPage.tsx
+++ b/prototype/frontend/src/pages/FrontPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import RegistrationForm from '../components/RegistrationForm';
 import LoginForm from '../components/LoginForm';
@@ -33,7 +33,23 @@ type View = 'register' | 'login';
 function FrontPage() {
   const [view, setView] = useState<View>('login');
   const navigate = useNavigate();
-  const { refreshUser } = useAuth();
+  const { user, loading, refreshUser } = useAuth();
+
+  // If the user is already authenticated (e.g. returning to the site with a
+  // valid token in localStorage), skip the login screen and go to the dashboard.
+  if (!loading && user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  // While restoring the session from localStorage, show a minimal loading
+  // state instead of flashing the login form.
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background text-primary flex items-center justify-center">
+        <div className="text-xl">Loading...</div>
+      </div>
+    );
+  }
 
   /**
    * Shared success handler for both login and registration forms.

--- a/prototype/frontend/src/utils/apiClient.ts
+++ b/prototype/frontend/src/utils/apiClient.ts
@@ -25,11 +25,24 @@ apiClient.interceptors.response.use(
     const isAuthRoute = url.includes('/api/auth/');
     const status = error.response?.status;
 
-    // Only clear token and redirect on definitive auth failures (401/403)
-    // from non-auth routes. Network errors (no response) should not trigger logout.
+    // Only clear token and redirect on definitive auth failures from our
+    // own backend. Proxy/WAF/DDoS layers (Cloudflare, Caddy, etc.) may
+    // also return 403, but those responses won't contain our JSON error
+    // format. We distinguish "backend says your token is bad" from
+    // "a proxy blocked this request" by checking the response body shape.
     if ((status === 401 || status === 403) && !isAuthRoute) {
-      localStorage.removeItem('token');
-      window.location.href = '/login';
+      const data = error.response?.data;
+      const isBackendAuthError =
+        data && typeof data === 'object' && typeof data.error === 'string';
+
+      if (isBackendAuthError) {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+      } else {
+        // Proxy/WAF block — don't destroy the session. The token may
+        // still be perfectly valid; the request was just rejected upstream.
+        console.warn('Non-backend 401/403 received (possible proxy/WAF block), keeping session:', status, url);
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
- FrontPage now redirects authenticated users to /dashboard instead of showing the login form (root cause of 'logged out' reports)
- Show loading state on FrontPage while auth initializes to prevent login form flash
- apiClient and AuthContext now distinguish backend auth errors from proxy/WAF 401/403 responses before clearing the session