### PR TITLE
feat(tournament): add bracket visualization with seeding display

### DIFF
--- a/.kiro/specs/tournament-bracket-seeding/.config.kiro
+++ b/.kiro/specs/tournament-bracket-seeding/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "14b43a70-8c13-4c2d-8031-73b87e67617e", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/tournament-bracket-seeding/design.md
+++ b/.kiro/specs/tournament-bracket-seeding/design.md
@@ -1,0 +1,405 @@
+# Design Document: Tournament Bracket Seeding
+
+## Overview
+
+This feature transforms the tournament viewing experience from a flat, modal-based current-round list into a full bracket visualization on a dedicated detail page. The backend already generates all `TournamentMatch` records upfront (including future-round placeholders) and seeds robots by ELO using `generateStandardSeedOrder()`. The work involves:
+
+1. **Backend**: Modify `GET /api/tournaments/:id` to return all matches across all rounds (not just current round) with robot relations, and compute a `seedings` array from round-1 match data and bracket positions.
+2. **Frontend**: Add a `/tournaments/:id` route with a `TournamentDetailPage`, replace the modal in `TournamentsPage`, and build a `BracketView` component that renders the single-elimination tree with match cards, seed labels, round columns, user highlighting, and mobile-responsive alternative views.
+
+No database schema changes are required — all data already exists in the `Tournament` and `TournamentMatch` tables.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Backend
+        A[GET /api/tournaments/:id] --> B[Prisma Query: All Matches + Robot Relations]
+        B --> C[Compute Seedings Array]
+        C --> D[Return JSON Response]
+    end
+
+    subgraph Frontend
+        E[TournamentsPage - List] -->|navigate| F[TournamentDetailPage]
+        F --> G[useTournamentDetail hook]
+        G -->|fetch| A
+        F --> H[BracketView]
+        H --> I[RoundColumn]
+        I --> J[MatchCard]
+        H --> K[SeedingList Panel]
+        F --> L[MobileView]
+        L --> M[MyPathView]
+        L --> N[RoundListView]
+    end
+```
+
+### Key Design Decisions
+
+1. **Seedings computed server-side**: The seedings array is derived on the backend by reading round-1 matches and reversing the `generateStandardSeedOrder()` mapping. This avoids duplicating the seeding algorithm on the frontend and keeps the API as the single source of truth.
+
+2. **No schema changes**: The existing `TournamentMatch` table already stores all rounds with `robot1Id`, `robot2Id`, `round`, and `matchNumber`. We just need to remove the `where: { round: { lte: currentRound } }` filter and include robot relations.
+
+3. **CSS-based bracket layout**: The bracket tree uses CSS Grid for round columns and flexbox for vertical match positioning. Connector lines between rounds use CSS pseudo-elements. This avoids heavy canvas/SVG libraries and keeps the bundle small.
+
+4. **Responsive strategy**: Below 768px, the bracket switches to a list-based view (round-by-round or "My Path"). On desktop with large brackets (>64 round-1 matches), CSS `transform: scale()` with wheel/pinch handlers enables zoom and pan.
+
+## Components and Interfaces
+
+### Backend Components
+
+#### Modified: `GET /api/tournaments/:id` (tournaments.ts)
+
+Current behavior returns matches only up to `currentRound`. The modified endpoint returns all matches across all rounds with robot details, plus a computed `seedings` array.
+
+```typescript
+// Response shape
+interface TournamentDetailResponse {
+  success: boolean;
+  tournament: {
+    id: number;
+    name: string;
+    tournamentType: string;
+    status: 'pending' | 'active' | 'completed';
+    currentRound: number;
+    maxRounds: number;
+    totalParticipants: number;
+    winnerId: number | null;
+    createdAt: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    winner: { id: number; name: string; elo: number } | null;
+    matches: TournamentMatchWithRobots[];
+  };
+  seedings: SeedEntry[];
+  timestamp: string;
+}
+
+interface TournamentMatchWithRobots {
+  id: number;
+  tournamentId: number;
+  round: number;
+  matchNumber: number;
+  robot1Id: number | null;
+  robot2Id: number | null;
+  winnerId: number | null;
+  battleId: number | null;
+  status: 'pending' | 'scheduled' | 'completed';
+  isByeMatch: boolean;
+  completedAt: string | null;
+  robot1: { id: number; name: string; elo: number } | null;
+  robot2: { id: number; name: string; elo: number } | null;
+  winner: { id: number; name: string } | null;
+}
+
+interface SeedEntry {
+  seed: number;       // 1-based seed number
+  robotId: number;
+  robotName: string;
+  elo: number;
+  eliminated: boolean; // true if robot has lost a match
+}
+```
+
+#### New: `computeSeedings()` (tournamentService.ts)
+
+A pure function that takes round-1 matches, the bracket size, and the `generateStandardSeedOrder()` output to produce the seedings array. The algorithm:
+
+1. Get all round-1 matches ordered by `matchNumber`.
+2. For each match at position `i` (0-based), the two bracket slots are `2*i` and `2*i+1`.
+3. Use the inverse of `generateStandardSeedOrder(bracketSize)` to map bracket slot → seed number.
+4. Collect `{ seed, robotId, robotName, elo }` for every non-null robot.
+5. Sort by seed ascending.
+6. Mark `eliminated: true` for any robot that appears as a loser in any completed match.
+
+This function is exported for testing.
+
+### Frontend Components
+
+#### New: `TournamentDetailPage` (pages/TournamentDetailPage.tsx)
+
+- Route: `/tournaments/:id`
+- Fetches tournament data via `tournamentApi.getTournamentDetails()`
+- Renders header info (name, status, round, participants, champion)
+- Contains `BracketView` as primary content
+- Back link to `/tournaments`
+- Error state with retry button
+- Loading skeleton
+
+#### Modified: `TournamentsPage` (pages/TournamentsPage.tsx)
+
+- Replace `fetchTournamentDetails()` + modal with `navigate(`/tournaments/${id}`)`
+- Remove the modal JSX entirely
+- Remove `selectedTournament`, `detailsLoading`, `matchesPage`, `matchesPerPage`, `showOnlyUserRobots` state
+
+#### New: `BracketView` (components/tournament/BracketView.tsx)
+
+Top-level bracket container. Manages:
+- Desktop vs mobile detection via `window.innerWidth` / media query hook
+- Zoom/pan state for large brackets (desktop)
+- Delegates to `DesktopBracket` or `MobileBracket`
+
+#### New: `DesktopBracket` (components/tournament/DesktopBracket.tsx)
+
+- CSS Grid layout: one column per round
+- Each `RoundColumn` contains vertically-spaced `MatchCard` components
+- Connector lines (CSS pseudo-elements) link match pairs to their next-round match
+- Horizontal scroll via `overflow-x: auto`
+- Pinch-to-zoom when round-1 matches > 64: uses CSS `transform: scale()` with wheel and touch event handlers
+
+#### New: `RoundColumn` (components/tournament/RoundColumn.tsx)
+
+- Renders round label ("Round 1", "Quarter-finals", "Semi-finals", "Finals")
+- Contains match cards for that round
+- Highlights current round with accent border
+
+#### New: `MatchCard` (components/tournament/MatchCard.tsx)
+
+- Displays two robot slots
+- States: completed (winner green, loser dimmed), pending (neutral + "Pending"), placeholder (TBD), bye ("Bye" label)
+- Seed number prefix for seeds 1-32: `#1 RobotName`
+- Highlight border when match contains user's robot
+- Subtle future-path indicator for user's potential matches
+
+#### New: `SeedingList` (components/tournament/SeedingList.tsx)
+
+- Collapsible side panel
+- Lists all participants by seed
+- Shows seed number (for top 32), robot name, ELO
+- Strikethrough/dimmed for eliminated robots
+- Highlight for user's own robots
+
+#### New: `MobileBracket` (components/tournament/MobileBracket.tsx)
+
+- Two view modes: "My Path" and "Round List"
+- Toggle between modes
+- **My Path**: Shows only matches involving user's robot(s) in a vertical timeline
+- **Round List**: Shows one round at a time with prev/next navigation, collapsible rounds
+
+#### Modified: `tournamentApi.ts` (utils/tournamentApi.ts)
+
+- Update `TournamentDetails` interface to include `seedings` array
+- Update `getTournamentDetails()` to pass through the `seedings` field from the response
+
+#### New: `useMediaQuery` hook (hooks/useMediaQuery.ts)
+
+Simple hook wrapping `window.matchMedia` for responsive breakpoint detection.
+
+### Utility Functions
+
+#### `getRoundLabel(round: number, maxRounds: number): string`
+
+Already exists as `getRoundName()` in `TournamentsPage.tsx`. Extract to a shared utility:
+- `maxRounds - round === 0` → "Finals"
+- `maxRounds - round === 1` → "Semi-finals"
+- `maxRounds - round === 2` → "Quarter-finals"
+- Otherwise → `"Round ${round}"`
+
+#### `buildBracketTree(matches: TournamentMatchWithRobots[], maxRounds: number)`
+
+Organizes flat match array into a `Map<number, TournamentMatchWithRobots[]>` keyed by round number, for efficient rendering.
+
+## Data Models
+
+### Existing Models (No Changes)
+
+**Tournament** (Prisma)
+- `id`, `name`, `tournamentType`, `status`, `currentRound`, `maxRounds`, `totalParticipants`, `winnerId`, `createdAt`, `startedAt`, `completedAt`
+
+**TournamentMatch** (Prisma)
+- `id`, `tournamentId`, `round`, `matchNumber`, `robot1Id`, `robot2Id`, `winnerId`, `battleId`, `status`, `isByeMatch`, `createdAt`, `completedAt`
+
+### New Frontend Types
+
+```typescript
+// Seed entry returned by API
+interface SeedEntry {
+  seed: number;
+  robotId: number;
+  robotName: string;
+  elo: number;
+  eliminated: boolean;
+}
+
+// Bracket organized by round for rendering
+type BracketRounds = Map<number, TournamentMatchWithRobots[]>;
+
+// Zoom/pan state for desktop bracket
+interface BracketViewState {
+  scale: number;
+  translateX: number;
+  translateY: number;
+}
+```
+
+### Seedings Computation
+
+The seedings array is computed from round-1 matches using the inverse of the bracket position algorithm:
+
+```
+bracketSize = 2^maxRounds
+seedOrder = generateStandardSeedOrder(bracketSize)  // e.g., [1, 16, 8, 9, 5, 12, ...]
+
+For each round-1 match at index i (0-based, ordered by matchNumber):
+  slot0 = 2 * i       → robot1 has seed = seedOrder[slot0]
+  slot1 = 2 * i + 1   → robot2 has seed = seedOrder[slot1]
+```
+
+This means `computeSeedings()` only needs the round-1 matches and the bracket size. It does not need to re-sort by ELO — the seed numbers are positional.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: API returns all matches across all rounds in correct order
+
+*For any* tournament with `maxRounds` rounds, the `GET /api/tournaments/:id` response SHALL contain every `TournamentMatch` record for that tournament, and the matches array SHALL be sorted by `(round ASC, matchNumber ASC)` — i.e., for any two adjacent matches in the array, the first has a round ≤ the second, and within the same round, a matchNumber ≤ the next.
+
+**Validates: Requirements 1.1, 1.4**
+
+### Property 2: Match robot relations are correctly populated
+
+*For any* `TournamentMatch` in the API response, if `robot1Id` is non-null then `robot1` SHALL be an object with `id`, `name`, and `elo` fields where `robot1.id === robot1Id`; if `robot1Id` is null then `robot1` SHALL be null. The same holds for `robot2` and `winner`.
+
+**Validates: Requirements 1.2, 1.3**
+
+### Property 3: Seedings round-trip — ELO ordering is preserved through bracket placement
+
+*For any* set of robots with distinct ELO ratings placed into a tournament bracket via `seedRobotsByELO()` and `generateStandardSeedOrder()`, the `computeSeedings()` function extracting seed numbers from round-1 match positions SHALL produce a seedings array where seed 1 has the highest ELO, seed 2 has the second-highest ELO, and so on — i.e., the seedings array sorted by seed ascending has strictly descending ELO values.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 4: Bracket renders correct structure per round
+
+*For any* tournament with `maxRounds` rounds, the bracket component SHALL render exactly `maxRounds` round columns, and for each round `r`, the number of match cards in that column SHALL equal the number of `TournamentMatch` records with `round === r`.
+
+**Validates: Requirements 3.1, 3.2**
+
+### Property 5: Completed match card highlights winner and dims loser
+
+*For any* completed `TournamentMatch` (status === 'completed', winnerId non-null), the rendered `MatchCard` SHALL apply the winner highlight class to the robot whose id matches `winnerId` and the dimmed/loser class to the other robot.
+
+**Validates: Requirements 3.3**
+
+### Property 6: Seed display threshold — top 32 seeds show number, others don't
+
+*For any* robot entry with a seed number, if `seed <= 32` then the rendered output (in both `MatchCard` and `SeedingList`) SHALL contain the seed prefix (e.g., "#N"), and if `seed > 32` then the rendered output SHALL NOT contain a seed prefix.
+
+**Validates: Requirements 4.1, 4.2, 5.3, 5.4**
+
+### Property 7: Seeding list contains all participants with correct data
+
+*For any* tournament with `totalParticipants` participants, the `SeedingList` SHALL render exactly `totalParticipants` entries, each displaying the robot name and ELO, ordered by seed number ascending from 1 to `totalParticipants`.
+
+**Validates: Requirements 5.1, 5.2**
+
+### Property 8: User robot matches are highlighted in bracket
+
+*For any* tournament and any set of user-owned robot IDs, every `MatchCard` where `robot1Id` or `robot2Id` is in the user's robot set SHALL have the user-highlight CSS class applied, and every `MatchCard` where neither robot belongs to the user SHALL NOT have that class.
+
+**Validates: Requirements 6.1, 6.2, 6.4**
+
+### Property 9: Future path prediction identifies correct match slots
+
+*For any* active tournament and any user robot that has not been eliminated, the set of future-round match slots highlighted SHALL be exactly the matches the robot would play in if it wins every remaining match — computed by following the bracket tree from the robot's current match position upward through each subsequent round.
+
+**Validates: Requirements 6.3**
+
+### Property 10: Round labels follow naming convention
+
+*For any* round number `r` and `maxRounds` value, `getRoundLabel(r, maxRounds)` SHALL return "Finals" when `r === maxRounds`, "Semi-finals" when `r === maxRounds - 1`, "Quarter-finals" when `r === maxRounds - 2`, and `"Round ${r}"` for all other values of `r`.
+
+**Validates: Requirements 7.1**
+
+### Property 11: My Path view contains exactly the user's matches
+
+*For any* tournament and user robot, the "My Path" mobile view SHALL display exactly the set of matches where `robot1Id` or `robot2Id` equals the user's robot ID, plus the connected future-path matches, and no other matches.
+
+**Validates: Requirements 9.2**
+
+### Property 12: Eliminated robots are visually indicated in seeding list
+
+*For any* robot that has lost a match in the tournament (appears as the non-winner in a completed match), the corresponding `SeedingList` entry SHALL have the eliminated visual indicator class applied.
+
+**Validates: Requirements 5.5**
+
+## Error Handling
+
+### Backend Errors
+
+| Error Condition | HTTP Status | Response | Handling |
+|---|---|---|---|
+| Invalid tournament ID (non-numeric) | 400 | `{ error: "Invalid tournament ID" }` | Existing behavior, unchanged |
+| Tournament not found | 404 | `{ error: "Tournament not found" }` | Existing behavior, unchanged |
+| Database query failure | 500 | `{ error: "Failed to fetch tournament details" }` | Log error, return generic message |
+| Seedings computation failure (corrupt data) | 500 | `{ error: "Failed to compute seedings" }` | Log error with tournament ID, return tournament data without seedings as fallback |
+
+### Frontend Errors
+
+| Error Condition | UI Behavior |
+|---|---|
+| API request fails (network/500) | Show error message with "Retry" button on `TournamentDetailPage` |
+| Tournament not found (404) | Show "Tournament not found" message with link back to list |
+| Empty matches array | Show bracket skeleton with "No matches available" message |
+| Missing seedings data | Render bracket without seed numbers (graceful degradation) |
+| User has no robots (for highlighting) | Render bracket without any highlights, no "My Path" option in mobile |
+
+### Edge Cases
+
+- **Tournament with 1 round** (2-4 participants): Bracket renders a single Finals column
+- **All bye matches in round 1**: Bracket shows round 1 with all byes, round 2 populated
+- **Tournament in "pending" status**: Bracket shows round 1 matches, all in pending state
+- **Very large tournaments (128+ participants)**: Desktop zoom/pan enabled, mobile defaults to round list view
+
+## Testing Strategy
+
+### Property-Based Testing
+
+Use **fast-check** (already in the project's test dependencies) for property-based tests. Each property test runs a minimum of 100 iterations.
+
+**Backend property tests** (`prototype/backend/src/__tests__/tournament-bracket-seeding.property.test.ts`):
+
+1. **Property 3 test**: Generate random arrays of 4-128 robots with random ELO values. Run `seedRobotsByELO()` → `generateStandardSeedOrder()` → `computeSeedings()`. Assert seedings are in descending ELO order.
+   - Tag: `Feature: tournament-bracket-seeding, Property 3: Seedings round-trip`
+
+2. **Property 10 test**: Generate random `(round, maxRounds)` pairs where `1 <= round <= maxRounds` and `maxRounds >= 1`. Assert `getRoundLabel()` returns the correct string per the naming rules.
+   - Tag: `Feature: tournament-bracket-seeding, Property 10: Round labels follow naming convention`
+
+3. **Property 1 test**: Generate random tournament match arrays with varying rounds and match numbers. Pass through the ordering logic and assert the output is sorted by `(round, matchNumber)`.
+   - Tag: `Feature: tournament-bracket-seeding, Property 1: API returns all matches in correct order`
+
+4. **Property 6 test**: Generate random seed numbers (1-500) and robot names. Assert the seed display function shows prefix for seeds ≤ 32 and omits it for seeds > 32.
+   - Tag: `Feature: tournament-bracket-seeding, Property 6: Seed display threshold`
+
+**Frontend property tests** (`prototype/frontend/src/__tests__/tournament-bracket-seeding.property.test.ts`):
+
+5. **Property 4 test**: Generate random tournament data with 1-7 rounds. Render `BracketView` and assert correct number of round columns and match cards per round.
+   - Tag: `Feature: tournament-bracket-seeding, Property 4: Bracket renders correct structure`
+
+6. **Property 8 test**: Generate random match data and random user robot ID sets. Assert highlight class is applied if and only if the match contains a user robot.
+   - Tag: `Feature: tournament-bracket-seeding, Property 8: User robot match highlighting`
+
+### Unit Tests (Examples and Edge Cases)
+
+**Backend unit tests**:
+- `computeSeedings()` with a known 8-robot tournament: verify exact seed assignments
+- `computeSeedings()` with bye matches (e.g., 5 robots in 8-slot bracket): verify all 5 robots appear
+- API response shape for a completed tournament with winner
+- API response for a tournament with all placeholder matches (round 2+)
+
+**Frontend unit tests**:
+- `MatchCard` renders "TBD" for placeholder matches (Req 3.5)
+- `MatchCard` renders "Bye" label for bye matches (Req 3.6)
+- `MatchCard` renders "Pending" for pending matches with two robots (Req 3.4)
+- `TournamentDetailPage` shows error + retry on API failure (Req 8.5)
+- `TournamentDetailPage` shows champion info when winner exists (Req 8.6)
+- `TournamentsPage` navigates to `/tournaments/:id` on click (Req 8.1)
+- Mobile view defaults to round list when user has no robot (Req 9.3)
+- Current round column has active styling (Req 7.2)
+
+### Test Configuration
+
+- Property-based tests: minimum 100 iterations per property via `fc.assert(fc.property(...), { numRuns: 100 })`
+- Each property test tagged with comment: `// Feature: tournament-bracket-seeding, Property N: <title>`
+- Frontend tests use React Testing Library + jsdom
+- Backend tests use Jest with Prisma mocking

--- a/.kiro/specs/tournament-bracket-seeding/requirements.md
+++ b/.kiro/specs/tournament-bracket-seeding/requirements.md
@@ -1,0 +1,123 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds tournament bracket visualization and seeding display to the Armoured Souls tournament system. The bracket data already exists in the database (all rounds are generated upfront with `TournamentMatch` records). The current UI only shows a flat list of current-round matches in a modal. This feature replaces that with a proper bracket view on a dedicated tournament detail page showing the full tournament tree, seed rankings, defeated opponents, and possible future opponents. The backend API needs minor adjustments to return all matches (not just current round) with robot details, and the frontend needs a bracket component that renders the single-elimination tree structure. Only the top 32 seeds are prominently displayed with seed numbers to make them stand out.
+
+## Glossary
+
+- **Bracket_View**: A visual tree representation of all matches in a single-elimination tournament, organized by rounds from left to right, showing match connections between rounds
+- **Seed_Number**: A robot's ranking position in the tournament based on ELO at tournament creation time, where seed 1 is the highest-rated robot. Only the top 32 seeds have their seed number displayed in the UI
+- **Bracket_Component**: The React component responsible for rendering the tournament bracket tree on the frontend
+- **Tournament_API**: The backend endpoint `GET /api/tournaments/:id` that returns tournament data including matches and robot details
+- **Match_Card**: A UI element within the Bracket_View that displays a single match with both robots, their seed numbers (for top 32 seeds only), and the match result
+- **Seeding_List**: A ranked list of all tournament participants ordered by their seed number, displayed alongside or within the bracket
+- **Round_Column**: A vertical column in the Bracket_View representing all matches in a single round (e.g., Round 1, Quarter-finals, Semi-finals, Finals)
+- **Tournament_Detail_Page**: A dedicated full-page view at `/tournaments/:id` that displays the Bracket_View and all tournament information
+- **Tournament_List_Page**: The existing `/tournaments` page that displays a list of tournaments with summary information
+
+## Requirements
+
+### Requirement 1: Return Full Bracket Data from API
+
+**User Story:** As a player, I want the tournament details API to return all matches across all rounds with robot details, so that the frontend can render the complete bracket.
+
+#### Acceptance Criteria
+
+1. WHEN a client requests `GET /api/tournaments/:id`, THE Tournament_API SHALL return all TournamentMatch records for the tournament across all rounds, ordered by round ascending then matchNumber ascending
+2. WHEN a client requests `GET /api/tournaments/:id`, THE Tournament_API SHALL include robot1, robot2, and winner relations with each match, including each robot's id, name, and elo fields
+3. WHEN a TournamentMatch has null robot1Id or robot2Id (placeholder future-round match), THE Tournament_API SHALL return null for the corresponding robot relation
+4. THE Tournament_API SHALL include the tournament's totalParticipants, maxRounds, currentRound, and status fields in the response
+
+### Requirement 2: Compute and Return Seed Numbers
+
+**User Story:** As a player, I want to see each robot's seed number in the tournament, so that I can understand the seeding and relative strength of competitors.
+
+#### Acceptance Criteria
+
+1. WHEN a client requests `GET /api/tournaments/:id`, THE Tournament_API SHALL return a seedings array containing each participating robot's id, name, elo, and seed number (1-based rank by descending ELO at tournament entry)
+2. THE Tournament_API SHALL derive seed numbers from the round-1 matches and the bracket position algorithm, assigning seed 1 to the highest-ELO robot and incrementing sequentially
+3. WHEN a robot received a bye in round 1, THE Tournament_API SHALL still include that robot in the seedings array with the correct seed number
+
+### Requirement 3: Display Tournament Bracket Tree
+
+**User Story:** As a player, I want to see a visual bracket tree of the entire tournament, so that I can follow the progression from round 1 through the finals.
+
+#### Acceptance Criteria
+
+1. THE Bracket_Component SHALL render one Round_Column per round, arranged horizontally from round 1 on the left to the finals on the right
+2. THE Bracket_Component SHALL render one Match_Card per TournamentMatch within each Round_Column, vertically positioned so that each match in round N+1 aligns between its two feeder matches from round N
+3. WHEN a match is completed, THE Match_Card SHALL highlight the winning robot's name with a distinct visual style (green text or bold) and dim the losing robot
+4. WHEN a match has not yet been played and has two assigned robots, THE Match_Card SHALL display both robot names in a neutral style with a "Pending" indicator
+5. WHEN a match is a placeholder (future round with null robots), THE Match_Card SHALL display "TBD" placeholders for both robot slots
+6. WHEN a match is a bye match, THE Match_Card SHALL display the advancing robot's name and a "Bye" label instead of an opponent
+7. THE Bracket_Component SHALL support horizontal scrolling when the bracket exceeds the viewport width
+
+### Requirement 4: Display Seed Numbers on Match Cards for Top 32 Seeds
+
+**User Story:** As a player, I want to see seed numbers next to the top-seeded robots in the bracket, so that I can quickly identify the strongest competitors without cluttering every match card.
+
+#### Acceptance Criteria
+
+1. WHEN a robot's Seed_Number is 32 or lower (seeds 1 through 32), THE Match_Card SHALL display the Seed_Number as a prefix label next to the robot's name (e.g., "#1 RobotName")
+2. WHEN a robot's Seed_Number is greater than 32, THE Match_Card SHALL display only the robot's name without a seed number prefix
+3. WHEN a robot's seed number is not available (future-round placeholder), THE Match_Card SHALL display only the "TBD" placeholder without a seed number
+
+### Requirement 5: Display Seeding List with Top 32 Highlighted
+
+**User Story:** As a player, I want to see a ranked list of all tournament participants by seed, so that I can understand the full seeding order at a glance.
+
+#### Acceptance Criteria
+
+1. THE Bracket_View SHALL include a Seeding_List panel that displays all tournament participants ranked by Seed_Number from 1 to totalParticipants
+2. EACH entry in the Seeding_List SHALL display the robot name and ELO rating at tournament entry
+3. WHEN a robot's Seed_Number is 32 or lower (seeds 1 through 32), THE Seeding_List SHALL display the seed number alongside the robot name and ELO
+4. WHEN a robot's Seed_Number is greater than 32, THE Seeding_List SHALL display the robot name and ELO without a seed number prefix
+5. WHEN a robot has been eliminated from the tournament, THE Seeding_List SHALL visually indicate elimination status (e.g., strikethrough or dimmed text)
+6. WHEN a robot is the user's own robot, THE Seeding_List SHALL highlight that entry with a distinct visual style
+
+### Requirement 6: Highlight User's Robot Path Through Bracket
+
+**User Story:** As a player, I want my robot's matches highlighted in the bracket, so that I can easily track my progress, see defeated opponents, and identify possible future opponents.
+
+#### Acceptance Criteria
+
+1. WHEN the user has a robot participating in the tournament, THE Bracket_Component SHALL apply a distinct highlight style (e.g., colored border) to every Match_Card containing that robot
+2. WHEN the user has a robot participating in the tournament, THE Bracket_Component SHALL visually trace the path of completed matches leading to the user's robot's current position
+3. WHEN the user's robot is still active in the tournament, THE Bracket_Component SHALL apply a subtle indicator to the match slots the robot would play in future rounds if the robot continues to win
+4. WHEN the user has multiple robots in the tournament, THE Bracket_Component SHALL highlight all of them with the same distinct style
+
+### Requirement 7: Round Labels
+
+**User Story:** As a player, I want each round column labeled with a meaningful name, so that I can understand the tournament stage.
+
+#### Acceptance Criteria
+
+1. THE Bracket_Component SHALL display a label above each Round_Column using contextual names: "Finals" for the last round (1 round remaining), "Semi-finals" when 2 rounds remain, "Quarter-finals" when 3 rounds remain, and "Round N" for all earlier rounds
+2. WHEN the tournament is active, THE Bracket_Component SHALL visually distinguish the current round column from past and future rounds (e.g., brighter background or border accent)
+
+### Requirement 8: Tournament Detail Page Navigation
+
+**User Story:** As a player, I want to navigate to a dedicated tournament detail page when I click on a tournament, so that the bracket view has a full page to work with.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks on a tournament in the Tournament_List_Page, THE Tournament_List_Page SHALL navigate to the Tournament_Detail_Page at `/tournaments/:id` instead of opening a modal
+2. THE Tournament_Detail_Page SHALL display the tournament name, status, current round, total rounds, total participants, and creation date
+3. THE Tournament_Detail_Page SHALL render the Bracket_View as the primary content area, using the full page width
+4. THE Tournament_Detail_Page SHALL include a navigation link back to the Tournament_List_Page
+5. IF the tournament data fails to load, THEN THE Tournament_Detail_Page SHALL display an error message with a retry option
+6. WHEN the tournament has a winner, THE Tournament_Detail_Page SHALL display the champion information prominently
+
+### Requirement 9: Mobile Responsiveness for Large Brackets
+
+**User Story:** As a player on a mobile device, I want to view large tournament brackets in a usable way, so that I can follow the tournament on any screen size.
+
+#### Acceptance Criteria
+
+1. WHEN the viewport width is below 768px, THE Bracket_Component SHALL display a simplified mobile-friendly layout instead of the full horizontal bracket tree
+2. WHEN in mobile view, THE Bracket_Component SHALL provide a "My Path" focused view that shows only the matches involving the user's robot and the connected bracket path, reducing visual clutter
+3. WHEN in mobile view and the user has no robot in the tournament, THE Bracket_Component SHALL default to a round-by-round list view that displays one round at a time with navigation controls to switch between rounds
+4. WHEN in mobile view, THE Bracket_Component SHALL allow the user to switch between the focused path view and the round-by-round list view
+5. WHEN in desktop view with a large bracket (more than 64 matches in round 1), THE Bracket_Component SHALL support pinch-to-zoom and pan gestures for navigating the bracket
+6. WHEN in mobile view, THE Bracket_Component SHALL allow collapsing and expanding individual rounds in the list view to manage screen space

--- a/.kiro/specs/tournament-bracket-seeding/tasks.md
+++ b/.kiro/specs/tournament-bracket-seeding/tasks.md
@@ -1,0 +1,248 @@
+# Implementation Plan: Tournament Bracket Seeding
+
+## Overview
+
+Transform the tournament viewing experience from a flat modal-based view into a full bracket visualization on a dedicated detail page. Backend modifications return all matches with seedings data; frontend adds a new detail page with bracket tree, seeding list, user highlighting, and mobile-responsive views. No database schema changes required.
+
+## Tasks
+
+- [ ] 1. Backend: Modify tournament detail API and add seedings computation
+  - [x] 1.1 Export `generateStandardSeedOrder` from `tournamentService.ts` and implement `computeSeedings()`
+    - Export the existing `generateStandardSeedOrder()` function so it can be used by the API route and tests
+    - Export the existing `seedRobotsByELO()` function for test usage
+    - Create and export a `computeSeedings(round1Matches, bracketSize)` function that:
+      - Takes round-1 matches ordered by matchNumber and the bracket size (2^maxRounds)
+      - Uses the inverse of `generateStandardSeedOrder(bracketSize)` to map bracket slot → seed number
+      - Collects `{ seed, robotId, robotName, elo, eliminated }` for every non-null robot
+      - Marks `eliminated: true` for any robot that lost a completed match (passed as parameter)
+      - Returns the array sorted by seed ascending
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [x] 1.2 Modify `GET /api/tournaments/:id` to return all matches and seedings
+    - Remove the `where: { round: { lte: currentRound } }` filter so all matches across all rounds are returned
+    - Include `robot1`, `robot2`, and `winner` relations on each match with `id`, `name`, `elo` fields
+    - Order matches by `round ASC, matchNumber ASC`
+    - Include `totalParticipants`, `maxRounds`, `currentRound`, `status` in the tournament response
+    - Call `computeSeedings()` with round-1 matches and bracket size, include `seedings` array in response
+    - Wrap seedings computation in try/catch — on failure, log error and return response without seedings (graceful degradation)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3_
+
+  - [x] 1.3 Write property test: Seedings round-trip (Property 3)
+    - **Property 3: Seedings round-trip — ELO ordering is preserved through bracket placement**
+    - Generate random arrays of 4–128 robots with distinct random ELO values using fast-check
+    - Run `seedRobotsByELO()` → `generateStandardSeedOrder()` → simulate round-1 match placement → `computeSeedings()`
+    - Assert seedings sorted by seed ascending have strictly descending ELO values
+    - Place test in `prototype/backend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 3: Seedings round-trip`
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+
+  - [x] 1.4 Write property test: API returns all matches in correct order (Property 1)
+    - **Property 1: API returns all matches across all rounds in correct order**
+    - Generate random tournament match arrays with varying rounds and match numbers
+    - Pass through the ordering logic and assert output is sorted by `(round ASC, matchNumber ASC)`
+    - Place test in `prototype/backend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 1: API returns all matches in correct order`
+    - **Validates: Requirements 1.1, 1.4**
+
+  - [x] 1.5 Write property test: Round labels follow naming convention (Property 10)
+    - **Property 10: Round labels follow naming convention**
+    - Generate random `(round, maxRounds)` pairs where `1 <= round <= maxRounds` and `maxRounds >= 1`
+    - Assert `getRoundLabel()` returns "Finals" when `round === maxRounds`, "Semi-finals" when `round === maxRounds - 1`, "Quarter-finals" when `round === maxRounds - 2`, and `"Round N"` otherwise
+    - Place test in `prototype/backend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 10: Round labels follow naming convention`
+    - **Validates: Requirements 7.1**
+
+  - [x] 1.6 Write property test: Seed display threshold (Property 6)
+    - **Property 6: Seed display threshold — top 32 seeds show number, others don't**
+    - Generate random seed numbers (1–500) and robot names
+    - Assert the seed display utility shows prefix for seeds ≤ 32 and omits it for seeds > 32
+    - Place test in `prototype/backend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 6: Seed display threshold`
+    - **Validates: Requirements 4.1, 4.2, 5.3, 5.4**
+
+- [x] 2. Checkpoint - Ensure backend tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 3. Frontend: Shared utilities and API client updates
+  - [x] 3.1 Extract `getRoundLabel()` utility and create shared bracket helpers
+    - Create `prototype/frontend/src/utils/bracketUtils.ts`
+    - Extract `getRoundName()` from `TournamentsPage.tsx` into `getRoundLabel(round, maxRounds)` following the design spec naming convention
+    - Implement `buildBracketTree(matches, maxRounds)` that organizes flat match array into `Map<number, TournamentMatchWithRobots[]>` keyed by round
+    - Implement `formatSeedDisplay(seed: number, robotName: string)` that returns `"#N RobotName"` for seeds ≤ 32 and just `robotName` for seeds > 32
+    - Implement `getUserFuturePath(matches, userRobotIds, maxRounds)` that computes the set of future match IDs the user's robot would play if it keeps winning
+    - _Requirements: 7.1, 4.1, 4.2, 6.3_
+
+  - [x] 3.2 Update `tournamentApi.ts` types and `getTournamentDetails()`
+    - Add `SeedEntry` interface: `{ seed, robotId, robotName, elo, eliminated }`
+    - Update `TournamentDetails` interface to include `seedings: SeedEntry[]`
+    - Update `TournamentMatchWithRobots` type to include robot `elo` field and `winner` relation
+    - Update `getTournamentDetails()` to pass through the `seedings` field from the API response
+    - _Requirements: 1.2, 2.1_
+
+  - [x] 3.3 Create `useMediaQuery` hook
+    - Create `prototype/frontend/src/hooks/useMediaQuery.ts`
+    - Simple hook wrapping `window.matchMedia` for responsive breakpoint detection
+    - Export a convenience `useIsMobile()` that checks `(max-width: 768px)`
+    - _Requirements: 9.1_
+
+- [ ] 4. Frontend: Tournament Detail Page and routing
+  - [x] 4.1 Create `TournamentDetailPage` component
+    - Create `prototype/frontend/src/pages/TournamentDetailPage.tsx`
+    - Route: `/tournaments/:id` — extract ID from URL params
+    - Fetch tournament data via `tournamentApi.getTournamentDetails()`
+    - Render header: tournament name, status badge, current round, total rounds, total participants, creation date
+    - Display champion info prominently when tournament has a winner
+    - Include back link to `/tournaments`
+    - Show loading skeleton while fetching
+    - Show error message with retry button on API failure
+    - Show "Tournament not found" with link back to list on 404
+    - Render `BracketView` as primary content using full page width
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 8.6_
+
+  - [x] 4.2 Add route for `/tournaments/:id` in the app router
+    - Add `<Route path="/tournaments/:id" element={<TournamentDetailPage />} />` to the app's router configuration
+    - Import `TournamentDetailPage` component
+    - _Requirements: 8.1_
+
+  - [x] 4.3 Modify `TournamentsPage` to navigate instead of opening modal
+    - Replace `fetchTournamentDetails()` + modal with `navigate(`/tournaments/${id}`)`
+    - Remove the modal JSX block entirely
+    - Remove `selectedTournament`, `detailsLoading`, `matchesPage`, `matchesPerPage`, `showOnlyUserRobots` state variables
+    - Keep the tournament list rendering, filter tabs, and stats overview unchanged
+    - Update `getRoundName` to use the shared `getRoundLabel` utility from `bracketUtils.ts`
+    - _Requirements: 8.1_
+
+- [ ] 5. Frontend: Bracket visualization components
+  - [x] 5.1 Create `BracketView` container component
+    - Create `prototype/frontend/src/components/tournament/BracketView.tsx`
+    - Accept tournament data (matches, seedings, maxRounds, currentRound, status, userRobotIds) as props
+    - Use `useIsMobile()` hook to switch between `DesktopBracket` and `MobileBracket`
+    - Manage zoom/pan state for large brackets on desktop
+    - _Requirements: 3.1, 3.7, 9.1_
+
+  - [x] 5.2 Create `DesktopBracket` component
+    - Create `prototype/frontend/src/components/tournament/DesktopBracket.tsx`
+    - CSS Grid layout: one column per round
+    - Use `buildBracketTree()` to organize matches by round
+    - Render `RoundColumn` for each round
+    - Draw connector lines between match pairs using CSS pseudo-elements
+    - Enable horizontal scrolling via `overflow-x: auto`
+    - Enable pinch-to-zoom/pan when round-1 matches > 64 using CSS `transform: scale()` with wheel and touch event handlers
+    - _Requirements: 3.1, 3.2, 3.7, 9.5_
+
+  - [x] 5.3 Create `RoundColumn` component
+    - Create `prototype/frontend/src/components/tournament/RoundColumn.tsx`
+    - Render round label using `getRoundLabel()` ("Round N", "Quarter-finals", "Semi-finals", "Finals")
+    - Contain `MatchCard` components for that round, vertically spaced so round N+1 matches align between their feeder matches
+    - Visually distinguish current round column with accent border/background when tournament is active
+    - _Requirements: 7.1, 7.2, 3.2_
+
+  - [x] 5.4 Create `MatchCard` component
+    - Create `prototype/frontend/src/components/tournament/MatchCard.tsx`
+    - Display two robot slots with the following states:
+      - Completed: winner name in green/bold, loser dimmed
+      - Pending (two robots assigned): both names neutral + "Pending" indicator
+      - Placeholder (null robots): "TBD" for both slots
+      - Bye: advancing robot name + "Bye" label
+    - Show seed number prefix `#N` for seeds 1–32 using `formatSeedDisplay()`
+    - Apply highlight border when match contains user's robot
+    - Apply subtle future-path indicator for user's potential future matches
+    - _Requirements: 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.3, 6.1, 6.2, 6.3, 6.4_
+
+  - [x] 5.5 Create `SeedingList` panel component
+    - Create `prototype/frontend/src/components/tournament/SeedingList.tsx`
+    - Collapsible side panel listing all participants by seed number ascending
+    - Show seed number for top 32, robot name, and ELO for each entry
+    - Omit seed number prefix for seeds > 32
+    - Strikethrough/dimmed styling for eliminated robots
+    - Highlight user's own robots with distinct visual style
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6_
+
+- [x] 6. Checkpoint - Ensure bracket renders correctly
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 7. Frontend: Mobile bracket views
+  - [x] 7.1 Create `MobileBracket` component
+    - Create `prototype/frontend/src/components/tournament/MobileBracket.tsx`
+    - Two view modes: "My Path" and "Round List" with toggle between them
+    - Default to "My Path" if user has a robot in the tournament, otherwise default to "Round List"
+    - _Requirements: 9.1, 9.4_
+
+  - [x] 7.2 Implement "My Path" view within `MobileBracket`
+    - Show only matches involving the user's robot(s) in a vertical timeline
+    - Include connected future-path matches
+    - _Requirements: 9.2_
+
+  - [x] 7.3 Implement "Round List" view within `MobileBracket`
+    - Display one round at a time with prev/next navigation controls
+    - Allow collapsing and expanding individual rounds to manage screen space
+    - Default view when user has no robot in the tournament
+    - _Requirements: 9.3, 9.6_
+
+- [ ] 8. Frontend: User robot highlighting and path tracing
+  - [x] 8.1 Implement user robot path highlighting in `DesktopBracket`
+    - Fetch user's robot IDs and pass to bracket components
+    - Apply distinct highlight style (colored border) to every `MatchCard` containing user's robot
+    - Visually trace the path of completed matches leading to user's current position
+    - Apply subtle indicator to future match slots the robot would play if it keeps winning (using `getUserFuturePath()`)
+    - Highlight all user robots if multiple participate
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [x] 8.2 Write property test: User robot match highlighting (Property 8)
+    - **Property 8: User robot matches are highlighted in bracket**
+    - Generate random match data and random user robot ID sets using fast-check
+    - Assert highlight class is applied if and only if the match contains a user robot
+    - Place test in `prototype/frontend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 8: User robot match highlighting`
+    - **Validates: Requirements 6.1, 6.2, 6.4**
+
+  - [x] 8.3 Write property test: Bracket renders correct structure (Property 4)
+    - **Property 4: Bracket renders correct structure per round**
+    - Generate random tournament data with 1–7 rounds using fast-check
+    - Render bracket utility and assert correct number of round columns and match cards per round
+    - Place test in `prototype/frontend/src/__tests__/tournament-bracket-seeding.property.test.ts`
+    - Tag: `Feature: tournament-bracket-seeding, Property 4: Bracket renders correct structure`
+    - **Validates: Requirements 3.1, 3.2**
+
+- [x] 9. Checkpoint - Ensure all frontend components work together
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 10. Final integration and wiring
+  - [x] 10.1 Wire `TournamentDetailPage` end-to-end
+    - Ensure `TournamentDetailPage` fetches data, passes seedings and user robot IDs to `BracketView`
+    - Ensure `BracketView` correctly delegates to `DesktopBracket` or `MobileBracket` based on viewport
+    - Ensure `SeedingList` panel is rendered alongside the bracket
+    - Verify navigation from `TournamentsPage` list → `TournamentDetailPage` → back to list works
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+  - [x] 10.2 Write unit tests for key components
+    - Test `MatchCard` renders "TBD" for placeholder matches (Req 3.5)
+    - Test `MatchCard` renders "Bye" label for bye matches (Req 3.6)
+    - Test `MatchCard` renders "Pending" for pending matches with two robots (Req 3.4)
+    - Test `MatchCard` seed display (yellow #N for ≤32, hidden for >32)
+    - Test `MatchCard` user robot highlighting (blue border, ring, YOU badge)
+    - Test `MatchCard` dimmed and highlighted states
+    - Test `MatchCard` data-robot1-id / data-robot2-id attributes
+    - Test `SeedingList` top 32 limit, user robots section, click-to-scroll, collapse/expand
+    - Test `TournamentDetailPage` shows error + retry on API failure (Req 8.5)
+    - Test `TournamentDetailPage` shows champion info when winner exists (Req 8.6)
+    - Test `TournamentDetailPage` shows 404 state, loading skeleton, header info
+    - Test `computeSeedings()` with a known 8-robot tournament for exact seed assignments
+    - Test `computeSeedings()` with bye matches (5 robots in 8-slot bracket)
+    - Backend tests in `prototype/backend/tests/compute-seedings.unit.test.ts`
+    - Frontend tests in `prototype/frontend/src/__tests__/tournament-components.unit.test.tsx`
+    - _Requirements: 3.4, 3.5, 3.6, 8.5, 8.6, 2.1, 2.3_
+
+- [x] 11. Final checkpoint - Ensure all tests pass
+  - All 54 frontend tests pass (19 bracketUtils + 3 property + 32 component unit)
+  - All 15 backend tests pass (4 property + 11 computeSeedings unit)
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- No database schema changes are needed — all data already exists in Tournament and TournamentMatch tables
+- The design uses TypeScript throughout (backend Express + Prisma, frontend React + Tailwind)

--- a/prototype/backend/src/routes/tournaments.ts
+++ b/prototype/backend/src/routes/tournaments.ts
@@ -1,6 +1,6 @@
 import express, { Response } from 'express';
 import { authenticateToken, AuthRequest } from '../middleware/auth';
-import { getActiveTournaments } from '../services/tournamentService';
+import { getActiveTournaments, computeSeedings } from '../services/tournamentService';
 import prisma from '../lib/prisma';
 import logger from '../config/logger';
 
@@ -49,7 +49,7 @@ router.get('/', authenticateToken, async (req: AuthRequest, res: Response) => {
 
 /**
  * GET /api/tournaments/:id
- * Get tournament details (public access for all authenticated users)
+ * Get tournament details with all matches and seedings (public access for all authenticated users)
  */
 router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) => {
   try {
@@ -59,16 +59,17 @@ router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) =>
       return res.status(400).json({ error: 'Invalid tournament ID' });
     }
 
+    const robotSelect = { id: true, name: true, elo: true };
+
     const tournament = await prisma.tournament.findUnique({
       where: { id: tournamentId },
       include: {
-        winner: true,
+        winner: { select: robotSelect },
         matches: {
-          where: { round: { lte: await getCurrentRound(tournamentId) } },
           include: {
-            robot1: true,
-            robot2: true,
-            winner: true,
+            robot1: { select: robotSelect },
+            robot2: { select: robotSelect },
+            winner: { select: robotSelect },
           },
           orderBy: [{ round: 'asc' }, { matchNumber: 'asc' }],
         },
@@ -79,9 +80,42 @@ router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) =>
       return res.status(404).json({ error: 'Tournament not found' });
     }
 
+    // Compute seedings with graceful degradation
+    let seedings: ReturnType<typeof computeSeedings> = [];
+    try {
+      const round1Matches = tournament.matches
+        .filter((m) => m.round === 1)
+        .sort((a, b) => a.matchNumber - b.matchNumber);
+
+      const bracketSize = Math.pow(2, tournament.maxRounds);
+
+      const completedMatches = tournament.matches.filter(
+        (m) => m.status === 'completed'
+      );
+
+      seedings = computeSeedings(round1Matches, bracketSize, completedMatches);
+    } catch (seedError) {
+      logger.error(`[Tournaments] Failed to compute seedings for tournament ${tournamentId}:`, seedError);
+    }
+
     res.json({
       success: true,
-      tournament,
+      tournament: {
+        id: tournament.id,
+        name: tournament.name,
+        tournamentType: tournament.tournamentType,
+        status: tournament.status,
+        currentRound: tournament.currentRound,
+        maxRounds: tournament.maxRounds,
+        totalParticipants: tournament.totalParticipants,
+        winnerId: tournament.winnerId,
+        createdAt: tournament.createdAt,
+        startedAt: tournament.startedAt,
+        completedAt: tournament.completedAt,
+        winner: tournament.winner,
+        matches: tournament.matches,
+      },
+      seedings,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
@@ -92,16 +126,5 @@ router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) =>
     });
   }
 });
-
-/**
- * Helper function to get current round of a tournament
- */
-async function getCurrentRound(tournamentId: number): Promise<number> {
-  const tournament = await prisma.tournament.findUnique({
-    where: { id: tournamentId },
-    select: { currentRound: true },
-  });
-  return tournament?.currentRound || 1;
-}
 
 export default router;

--- a/prototype/backend/src/services/tournamentService.ts
+++ b/prototype/backend/src/services/tournamentService.ts
@@ -74,7 +74,7 @@ export async function getEligibleRobotsForTournament(): Promise<Robot[]> {
  * Seed robots by ELO rating (highest to lowest)
  * Used for fair bracket generation
  */
-function seedRobotsByELO(robots: Robot[]): Robot[] {
+export function seedRobotsByELO(robots: Robot[]): Robot[] {
   return [...robots].sort((a, b) => b.elo - a.elo);
 }
 
@@ -243,7 +243,7 @@ function generateBracketPairs(seededRobots: Robot[], maxRounds: number): Tournam
  * - Semifinals: 1v4 and 2v3
  * - Finals: 1v2
  */
-function generateStandardSeedOrder(bracketSize: number): number[] {
+export function generateStandardSeedOrder(bracketSize: number): number[] {
   if (bracketSize === 2) {
     return [1, 2];
   }
@@ -268,6 +268,131 @@ function generateStandardSeedOrder(bracketSize: number): number[] {
   }
   
   return result;
+}
+
+/**
+ * Seed entry representing a robot's seeding in a tournament bracket
+ */
+export interface SeedEntry {
+  seed: number;       // 1-based seed number
+  robotId: number;
+  robotName: string;
+  elo: number;
+  eliminated: boolean; // true if robot has lost a match
+}
+
+/**
+ * A round-1 match with robot relations for seedings computation.
+ * Matches must be ordered by matchNumber ascending.
+ */
+export interface Round1Match {
+  matchNumber: number;
+  robot1Id: number | null;
+  robot2Id: number | null;
+  robot1: { id: number; name: string; elo: number } | null;
+  robot2: { id: number; name: string; elo: number } | null;
+}
+
+/**
+ * A completed match used to determine elimination status.
+ */
+export interface CompletedMatch {
+  winnerId: number | null;
+  robot1Id: number | null;
+  robot2Id: number | null;
+  status: string;
+}
+
+/**
+ * Compute seedings array from round-1 matches and bracket size.
+ * 
+ * Algorithm:
+ * 1. Build inverse map from bracket slot → seed number using generateStandardSeedOrder
+ * 2. For each round-1 match at index i (0-based), bracket slots are 2*i and 2*i+1
+ * 3. Map each non-null robot to its seed number
+ * 4. Mark eliminated robots (losers in any completed match)
+ * 5. Return sorted by seed ascending
+ * 
+ * @param round1Matches - Round-1 matches ordered by matchNumber ascending
+ * @param bracketSize - Total bracket size (2^maxRounds)
+ * @param completedMatches - All completed matches to determine elimination
+ * @returns Array of SeedEntry sorted by seed ascending
+ */
+export function computeSeedings(
+  round1Matches: Round1Match[],
+  bracketSize: number,
+  completedMatches: CompletedMatch[]
+): SeedEntry[] {
+  // seedOrder[seedIndex] = bracketPosition (1-based)
+  // We need the inverse: bracketPosition → seedNumber (1-based)
+  const seedOrder = generateStandardSeedOrder(bracketSize);
+  const slotToSeed = new Map<number, number>();
+  for (let seedIdx = 0; seedIdx < seedOrder.length; seedIdx++) {
+    const bracketPos = seedOrder[seedIdx] - 1; // convert to 0-based slot
+    slotToSeed.set(bracketPos, seedIdx + 1);   // seed is 1-based
+  }
+
+  // Build set of eliminated robot IDs (losers in completed matches)
+  const eliminatedIds = new Set<number>();
+  for (const match of completedMatches) {
+    if (match.status === 'completed' && match.winnerId !== null) {
+      if (match.robot1Id !== null && match.robot1Id !== match.winnerId) {
+        eliminatedIds.add(match.robot1Id);
+      }
+      if (match.robot2Id !== null && match.robot2Id !== match.winnerId) {
+        eliminatedIds.add(match.robot2Id);
+      }
+    }
+  }
+
+  const seedings: SeedEntry[] = [];
+
+  for (let i = 0; i < round1Matches.length; i++) {
+    const match = round1Matches[i];
+    const slot0 = 2 * i;     // bracket slot for robot1
+    const slot1 = 2 * i + 1; // bracket slot for robot2
+
+    const isByeMatch = match.robot1 !== null && match.robot2 === null;
+
+    if (isByeMatch && match.robot1 !== null && match.robot1Id !== null) {
+      // Bye match: robot may have been normalized from either slot.
+      // Assign the lower (better) seed number of the two slots.
+      const seed = Math.min(slotToSeed.get(slot0) ?? bracketSize, slotToSeed.get(slot1) ?? bracketSize);
+      seedings.push({
+        seed,
+        robotId: match.robot1.id,
+        robotName: match.robot1.name,
+        elo: match.robot1.elo,
+        eliminated: eliminatedIds.has(match.robot1.id),
+      });
+    } else {
+      // Normal match with two robots
+      if (match.robot1 !== null && match.robot1Id !== null) {
+        seedings.push({
+          seed: slotToSeed.get(slot0) ?? 0,
+          robotId: match.robot1.id,
+          robotName: match.robot1.name,
+          elo: match.robot1.elo,
+          eliminated: eliminatedIds.has(match.robot1.id),
+        });
+      }
+
+      if (match.robot2 !== null && match.robot2Id !== null) {
+        seedings.push({
+          seed: slotToSeed.get(slot1) ?? 0,
+          robotId: match.robot2.id,
+          robotName: match.robot2.name,
+          elo: match.robot2.elo,
+          eliminated: eliminatedIds.has(match.robot2.id),
+        });
+      }
+    }
+  }
+
+  // Sort by seed ascending
+  seedings.sort((a, b) => a.seed - b.seed);
+
+  return seedings;
 }
 
 /**

--- a/prototype/backend/tests/compute-seedings.unit.test.ts
+++ b/prototype/backend/tests/compute-seedings.unit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for computeSeedings() with known tournament configurations.
+ * Feature: tournament-bracket-seeding, Task 10.2
+ *
+ * Tests exact seed assignments for:
+ * - A known 8-robot tournament (full bracket, no byes)
+ * - A 5-robot tournament in an 8-slot bracket (with bye matches)
+ */
+
+import {
+  seedRobotsByELO,
+  generateStandardSeedOrder,
+  computeSeedings,
+  Round1Match,
+  CompletedMatch,
+} from '../src/services/tournamentService';
+import type { Robot } from '@prisma/client';
+
+function makeRobot(id: number, name: string, elo: number): Robot {
+  return { id, name, elo } as Robot;
+}
+
+describe('computeSeedings — known 8-robot tournament', () => {
+  // 8 robots with distinct ELOs, sorted descending
+  const robots: Robot[] = [
+    makeRobot(1, 'Alpha', 2000),
+    makeRobot(2, 'Bravo', 1800),
+    makeRobot(3, 'Charlie', 1600),
+    makeRobot(4, 'Delta', 1400),
+    makeRobot(5, 'Echo', 1200),
+    makeRobot(6, 'Foxtrot', 1000),
+    makeRobot(7, 'Golf', 800),
+    makeRobot(8, 'Hotel', 600),
+  ];
+
+  const bracketSize = 8;
+  const seeded = seedRobotsByELO(robots);
+  const seedOrder = generateStandardSeedOrder(bracketSize);
+
+  // Place robots into bracket slots
+  const bracketSlots: (Robot | null)[] = new Array(bracketSize).fill(null);
+  for (let i = 0; i < seeded.length; i++) {
+    bracketSlots[seedOrder[i] - 1] = seeded[i];
+  }
+
+  // Build round-1 matches from consecutive pairs
+  const round1Matches: Round1Match[] = [];
+  let matchNum = 1;
+  for (let i = 0; i < bracketSize; i += 2) {
+    const r1 = bracketSlots[i];
+    const r2 = bracketSlots[i + 1];
+    round1Matches.push({
+      matchNumber: matchNum++,
+      robot1Id: r1?.id ?? null,
+      robot2Id: r2?.id ?? null,
+      robot1: r1 ? { id: r1.id, name: r1.name, elo: r1.elo } : null,
+      robot2: r2 ? { id: r2.id, name: r2.name, elo: r2.elo } : null,
+    });
+  }
+
+  it('should assign exactly 8 seedings', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    expect(seedings.length).toBe(8);
+  });
+
+  it('should assign seed 1 to the highest ELO robot', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    expect(seedings[0].seed).toBe(1);
+    expect(seedings[0].robotName).toBe('Alpha');
+    expect(seedings[0].elo).toBe(2000);
+  });
+
+  it('should assign seed 8 to the lowest ELO robot', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    expect(seedings[7].seed).toBe(8);
+    expect(seedings[7].robotName).toBe('Hotel');
+    expect(seedings[7].elo).toBe(600);
+  });
+
+  it('should have strictly descending ELO across seeds 1-8', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    for (let i = 0; i < seedings.length - 1; i++) {
+      expect(seedings[i].elo).toBeGreaterThan(seedings[i + 1].elo);
+    }
+  });
+
+  it('should mark no robots as eliminated when no completed matches', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    for (const entry of seedings) {
+      expect(entry.eliminated).toBe(false);
+    }
+  });
+
+  it('should mark losers as eliminated when completed matches are provided', () => {
+    // Alpha (id=1) beats Hotel (id=8) in match 1
+    const completedMatches: CompletedMatch[] = [
+      { robot1Id: 1, robot2Id: 8, winnerId: 1, status: 'completed' },
+    ];
+    const seedings = computeSeedings(round1Matches, bracketSize, completedMatches);
+
+    const hotel = seedings.find((s) => s.robotId === 8);
+    expect(hotel).toBeDefined();
+    expect(hotel!.eliminated).toBe(true);
+
+    const alpha = seedings.find((s) => s.robotId === 1);
+    expect(alpha).toBeDefined();
+    expect(alpha!.eliminated).toBe(false);
+  });
+});
+
+describe('computeSeedings — 5 robots in 8-slot bracket (bye matches)', () => {
+  const robots: Robot[] = [
+    makeRobot(10, 'Ace', 2500),
+    makeRobot(20, 'Baron', 2200),
+    makeRobot(30, 'Count', 1900),
+    makeRobot(40, 'Duke', 1600),
+    makeRobot(50, 'Earl', 1300),
+  ];
+
+  const bracketSize = 8;
+  const seeded = seedRobotsByELO(robots);
+  const seedOrder = generateStandardSeedOrder(bracketSize);
+
+  const bracketSlots: (Robot | null)[] = new Array(bracketSize).fill(null);
+  for (let i = 0; i < seeded.length; i++) {
+    bracketSlots[seedOrder[i] - 1] = seeded[i];
+  }
+
+  // Build round-1 matches, normalizing byes (actual robot in robot1)
+  const round1Matches: Round1Match[] = [];
+  let matchNum = 1;
+  for (let i = 0; i < bracketSize; i += 2) {
+    let r1 = bracketSlots[i];
+    let r2 = bracketSlots[i + 1];
+
+    if (r1 === null && r2 !== null) {
+      r1 = r2;
+      r2 = null;
+    }
+    if (r1 === null && r2 === null) continue;
+
+    round1Matches.push({
+      matchNumber: matchNum++,
+      robot1Id: r1?.id ?? null,
+      robot2Id: r2?.id ?? null,
+      robot1: r1 ? { id: r1.id, name: r1.name, elo: r1.elo } : null,
+      robot2: r2 ? { id: r2.id, name: r2.name, elo: r2.elo } : null,
+    });
+  }
+
+  it('should assign exactly 5 seedings (one per robot)', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    expect(seedings.length).toBe(5);
+  });
+
+  it('should assign seed 1 to the highest ELO robot', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    expect(seedings[0].seed).toBe(1);
+    expect(seedings[0].robotName).toBe('Ace');
+  });
+
+  it('should have strictly descending ELO across all seeds', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    for (let i = 0; i < seedings.length - 1; i++) {
+      expect(seedings[i].elo).toBeGreaterThan(seedings[i + 1].elo);
+    }
+  });
+
+  it('should have 3 bye matches (8 slots - 5 robots = 3 byes)', () => {
+    const byeCount = round1Matches.filter(
+      (m) => m.robot1 !== null && m.robot2 === null
+    ).length;
+    expect(byeCount).toBe(3);
+  });
+
+  it('should assign seeds 1-5 with no gaps', () => {
+    const seedings = computeSeedings(round1Matches, bracketSize, []);
+    const seeds = seedings.map((s) => s.seed);
+    expect(seeds).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/prototype/backend/tests/tournament-bracket-seeding.property.test.ts
+++ b/prototype/backend/tests/tournament-bracket-seeding.property.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tournament Bracket Seeding - Property-Based Tests
+ * Feature: tournament-bracket-seeding
+ *
+ * Tests the correctness properties of the tournament seeding system
+ * using fast-check for property-based testing.
+ */
+
+import * as fc from 'fast-check';
+import {
+  seedRobotsByELO,
+  generateStandardSeedOrder,
+  computeSeedings,
+  Round1Match,
+} from '../src/services/tournamentService';
+import type { Robot } from '@prisma/client';
+
+const NUM_RUNS = 100;
+
+/**
+ * Create a minimal Robot-like object for testing seeding logic.
+ * seedRobotsByELO only accesses .elo for sorting, and the bracket
+ * placement logic only uses .id, .name, and .elo.
+ */
+function makeRobot(id: number, name: string, elo: number): Robot {
+  return { id, name, elo } as Robot;
+}
+
+/**
+ * Compute the next power of 2 >= n.
+ */
+function nextPowerOf2(n: number): number {
+  return Math.pow(2, Math.ceil(Math.log2(n)));
+}
+
+// Feature: tournament-bracket-seeding, Property 3: Seedings round-trip
+describe('Feature: tournament-bracket-seeding', () => {
+  describe('Property 3: Seedings round-trip', () => {
+    /**
+     * **Validates: Requirements 2.1, 2.2, 2.3**
+     *
+     * For any set of robots with distinct ELO ratings placed into a tournament
+     * bracket via seedRobotsByELO() and generateStandardSeedOrder(), the
+     * computeSeedings() function extracting seed numbers from round-1 match
+     * positions SHALL produce a seedings array where seed 1 has the highest ELO,
+     * seed 2 has the second-highest ELO, and so on — i.e., the seedings array
+     * sorted by seed ascending has strictly descending ELO values.
+     */
+    it('should preserve ELO ordering through bracket placement', () => {
+      fc.assert(
+        fc.property(
+          // Generate N distinct ELO values for 4-128 robots
+          fc.integer({ min: 4, max: 128 }).chain((n) =>
+            fc.tuple(
+              fc.constant(n),
+              fc.uniqueArray(fc.integer({ min: 800, max: 3000 }), {
+                minLength: n,
+                maxLength: n,
+              })
+            )
+          ),
+          ([n, elos]) => {
+            // 1. Create N robots with distinct ELO values
+            const robots: Robot[] = elos.map((elo, i) =>
+              makeRobot(i + 1, `Robot-${i + 1}`, elo)
+            );
+
+            // 2. Sort by ELO descending
+            const seeded = seedRobotsByELO(robots);
+
+            // 3. Compute bracket size (next power of 2 >= N)
+            const bracketSize = nextPowerOf2(n);
+
+            // 4. Get seed order
+            const seedOrder = generateStandardSeedOrder(bracketSize);
+
+            // 5. Simulate round-1 match placement (same as generateBracketPairs)
+            const bracketSlots: (Robot | null)[] = new Array(bracketSize).fill(null);
+            for (let i = 0; i < seeded.length; i++) {
+              const bracketPosition = seedOrder[i] - 1;
+              bracketSlots[bracketPosition] = seeded[i];
+            }
+
+            // Create round-1 matches from consecutive pairs
+            const round1Matches: Round1Match[] = [];
+            let matchNumber = 1;
+            for (let i = 0; i < bracketSize; i += 2) {
+              let robot1 = bracketSlots[i];
+              let robot2 = bracketSlots[i + 1];
+
+              // Normalize bye matches: actual robot always in robot1
+              if (robot1 === null && robot2 !== null) {
+                robot1 = robot2;
+                robot2 = null;
+              }
+
+              if (robot1 === null && robot2 === null) {
+                continue;
+              }
+
+              round1Matches.push({
+                matchNumber: matchNumber++,
+                robot1Id: robot1?.id ?? null,
+                robot2Id: robot2?.id ?? null,
+                robot1: robot1
+                  ? { id: robot1.id, name: robot1.name, elo: robot1.elo }
+                  : null,
+                robot2: robot2
+                  ? { id: robot2.id, name: robot2.name, elo: robot2.elo }
+                  : null,
+              });
+            }
+
+            // 6. Compute seedings with empty completed matches
+            const seedings = computeSeedings(round1Matches, bracketSize, []);
+
+            // 7. Assert seedings sorted by seed ascending have strictly descending ELO
+            expect(seedings.length).toBe(n);
+
+            for (let i = 0; i < seedings.length; i++) {
+              expect(seedings[i].seed).toBe(i + 1);
+            }
+
+            for (let i = 0; i < seedings.length - 1; i++) {
+              expect(seedings[i].elo).toBeGreaterThan(seedings[i + 1].elo);
+            }
+          }
+        ),
+        { numRuns: NUM_RUNS }
+      );
+    });
+  });
+});
+
+// Feature: tournament-bracket-seeding, Property 1: API returns all matches in correct order
+describe('Feature: tournament-bracket-seeding', () => {
+  describe('Property 1: API returns all matches in correct order', () => {
+    /**
+     * **Validates: Requirements 1.1, 1.4**
+     *
+     * For any tournament with maxRounds rounds, the match array SHALL be sorted
+     * by (round ASC, matchNumber ASC) — i.e., for any two adjacent matches in
+     * the array, the first has round <= the second, and within the same round,
+     * matchNumber <= the next.
+     */
+    it('should return matches sorted by (round ASC, matchNumber ASC)', () => {
+      /**
+       * The ordering logic used by the API is:
+       *   orderBy: [{ round: 'asc' }, { matchNumber: 'asc' }]
+       *
+       * We replicate this with a standard JS sort comparator and verify
+       * the output satisfies the adjacency invariant.
+       */
+      fc.assert(
+        fc.property(
+          // Generate an array of 1-200 match objects with random round (1-7) and matchNumber (1-64)
+          fc.array(
+            fc.record({
+              round: fc.integer({ min: 1, max: 7 }),
+              matchNumber: fc.integer({ min: 1, max: 64 }),
+            }),
+            { minLength: 1, maxLength: 200 }
+          ),
+          (matches) => {
+            // Apply the same ordering logic the API uses: round ASC, matchNumber ASC
+            const sorted = [...matches].sort((a, b) => {
+              if (a.round !== b.round) return a.round - b.round;
+              return a.matchNumber - b.matchNumber;
+            });
+
+            // Assert: for every pair of adjacent matches, the ordering invariant holds
+            for (let i = 0; i < sorted.length - 1; i++) {
+              const current = sorted[i];
+              const next = sorted[i + 1];
+
+              // round must be non-decreasing
+              expect(current.round).toBeLessThanOrEqual(next.round);
+
+              // within the same round, matchNumber must be non-decreasing
+              if (current.round === next.round) {
+                expect(current.matchNumber).toBeLessThanOrEqual(next.matchNumber);
+              }
+            }
+          }
+        ),
+        { numRuns: NUM_RUNS }
+      );
+    });
+  });
+});
+
+// Feature: tournament-bracket-seeding, Property 10: Round labels follow naming convention
+describe('Feature: tournament-bracket-seeding', () => {
+  describe('Property 10: Round labels follow naming convention', () => {
+    /**
+     * **Validates: Requirements 7.1**
+     *
+     * For any round number r and maxRounds value, getRoundLabel(r, maxRounds)
+     * SHALL return "Finals" when r === maxRounds, "Semi-finals" when
+     * r === maxRounds - 1, "Quarter-finals" when r === maxRounds - 2,
+     * and "Round N" for all other values of r.
+     */
+
+    // Define getRoundLabel inline for testing (will be extracted to shared utility in Task 3.1)
+    function getRoundLabel(round: number, maxRounds: number): string {
+      if (round === maxRounds) return 'Finals';
+      if (round === maxRounds - 1) return 'Semi-finals';
+      if (round === maxRounds - 2) return 'Quarter-finals';
+      return `Round ${round}`;
+    }
+
+    it('should return correct round labels for any (round, maxRounds) pair', () => {
+      fc.assert(
+        fc.property(
+          // Generate maxRounds >= 1, then round in [1, maxRounds]
+          fc.integer({ min: 1, max: 20 }).chain((maxRounds) =>
+            fc.tuple(
+              fc.integer({ min: 1, max: maxRounds }),
+              fc.constant(maxRounds)
+            )
+          ),
+          ([round, maxRounds]) => {
+            const label = getRoundLabel(round, maxRounds);
+
+            if (round === maxRounds) {
+              expect(label).toBe('Finals');
+            } else if (round === maxRounds - 1) {
+              expect(label).toBe('Semi-finals');
+            } else if (round === maxRounds - 2) {
+              expect(label).toBe('Quarter-finals');
+            } else {
+              expect(label).toBe(`Round ${round}`);
+            }
+          }
+        ),
+        { numRuns: NUM_RUNS }
+      );
+    });
+  });
+});
+
+// Feature: tournament-bracket-seeding, Property 6: Seed display threshold
+describe('Feature: tournament-bracket-seeding', () => {
+  describe('Property 6: Seed display threshold', () => {
+    /**
+     * **Validates: Requirements 4.1, 4.2, 5.3, 5.4**
+     *
+     * For any robot entry with a seed number, if seed <= 32 then the rendered
+     * output SHALL contain the seed prefix (e.g., "#N"), and if seed > 32 then
+     * the rendered output SHALL NOT contain a seed prefix.
+     */
+
+    // Inline implementation — will be extracted to bracketUtils.ts in Task 3.1
+    function formatSeedDisplay(seed: number, robotName: string): string {
+      if (seed <= 32) return `#${seed} ${robotName}`;
+      return robotName;
+    }
+
+    it('should show seed prefix for seeds 1-32 and omit it for seeds > 32', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 500 }),
+          fc.string({ minLength: 1, maxLength: 30 }).filter((s) => s.trim().length > 0),
+          (seed, robotName) => {
+            const display = formatSeedDisplay(seed, robotName);
+
+            if (seed <= 32) {
+              // Must contain the seed prefix "#N "
+              expect(display).toBe(`#${seed} ${robotName}`);
+              expect(display).toContain(`#${seed}`);
+            } else {
+              // Must be just the robot name, no seed prefix
+              expect(display).toBe(robotName);
+              expect(display).not.toMatch(/^#\d+/);
+            }
+          }
+        ),
+        { numRuns: NUM_RUNS }
+      );
+    });
+  });
+});

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import LeaderboardsLossesPage from './pages/LeaderboardsLossesPage';
 import FinancialReportPage from './pages/FinancialReportPage';
 import HallOfRecordsPage from './pages/HallOfRecordsPage';
 import TournamentsPage from './pages/TournamentsPage';
+import TournamentDetailPage from './pages/TournamentDetailPage';
 import TagTeamManagementPage from './pages/TagTeamManagementPage';
 import TagTeamStandingsPage from './pages/TagTeamStandingsPage';
 import ProfilePage from './pages/ProfilePage';
@@ -170,6 +171,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <TournamentsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/tournaments/:id"
+            element={
+              <ProtectedRoute>
+                <TournamentDetailPage />
               </ProtectedRoute>
             }
           />

--- a/prototype/frontend/src/__tests__/tournament-bracket-seeding.property.test.ts
+++ b/prototype/frontend/src/__tests__/tournament-bracket-seeding.property.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { render } from '@testing-library/react';
+import React from 'react';
+import MatchCard from '../components/tournament/MatchCard';
+import {
+  buildBracketTree,
+  TournamentMatchWithRobots,
+} from '../utils/bracketUtils';
+
+/**
+ * Property-based tests for tournament bracket seeding (frontend)
+ * Feature: tournament-bracket-seeding
+ *
+ * Uses fast-check with minimum 100 iterations per property.
+ */
+
+/** Helper to create a minimal match object for testing */
+function makeMatch(
+  overrides: Partial<TournamentMatchWithRobots> & {
+    id: number;
+    round: number;
+    matchNumber: number;
+  }
+): TournamentMatchWithRobots {
+  return {
+    tournamentId: 1,
+    robot1Id: null,
+    robot2Id: null,
+    winnerId: null,
+    battleId: null,
+    status: 'pending',
+    isByeMatch: false,
+    completedAt: null,
+    robot1: null,
+    robot2: null,
+    winner: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Feature: tournament-bracket-seeding, Property 8: User robot match highlighting
+ *
+ * For any tournament and any set of user-owned robot IDs, every MatchCard where
+ * robot1Id or robot2Id is in the user's robot set SHALL have the border-blue-500
+ * CSS class applied, and every MatchCard where neither robot belongs to the user
+ * SHALL have border-gray-700 instead.
+ *
+ * **Validates: Requirements 6.1, 6.2, 6.4**
+ */
+describe('Property 8: User robot match highlighting', () => {
+  /** Arbitrary for a positive robot ID */
+  const robotIdArb = fc.integer({ min: 1, max: 10000 });
+
+  /** Arbitrary for a robot name */
+  const robotNameArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9 ]{0,14}$/).filter(
+    (s) => s.trim().length > 0
+  );
+
+  /** Arbitrary that generates a match with random robot IDs and a set of user robot IDs */
+  const matchAndUserRobotsArb = fc
+    .tuple(
+      fc.integer({ min: 1, max: 1000 }), // match id
+      fc.option(robotIdArb, { nil: undefined }), // robot1Id (possibly absent)
+      fc.option(robotIdArb, { nil: undefined }), // robot2Id (possibly absent)
+      robotNameArb, // robot1 name
+      robotNameArb, // robot2 name
+      fc.uniqueArray(robotIdArb, { minLength: 0, maxLength: 5 }) // user robot IDs
+    )
+    .map(([matchId, r1Id, r2Id, r1Name, r2Name, userIds]) => {
+      const robot1Id = r1Id ?? null;
+      const robot2Id = r2Id ?? null;
+
+      const match = makeMatch({
+        id: matchId,
+        round: 1,
+        matchNumber: 1,
+        robot1Id,
+        robot2Id,
+        robot1: robot1Id !== null ? { id: robot1Id, name: r1Name, elo: 1500 } : null,
+        robot2: robot2Id !== null ? { id: robot2Id, name: r2Name, elo: 1400 } : null,
+        status: 'pending',
+      });
+
+      const userRobotIds = new Set(userIds);
+      return { match, userRobotIds };
+    });
+
+  it('should apply border-blue-500 if and only if the match contains a user robot', () => {
+    fc.assert(
+      fc.property(matchAndUserRobotsArb, ({ match, userRobotIds }) => {
+        const { container } = render(
+          React.createElement(MatchCard, {
+            match,
+            seedMap: new Map(),
+            userRobotIds,
+            isUserFuturePath: false,
+          })
+        );
+
+        const card = container.querySelector(`[data-testid="match-card-${match.id}"]`);
+        expect(card).not.toBeNull();
+
+        const classList = card!.className;
+
+        const hasUserRobot =
+          (match.robot1Id !== null && userRobotIds.has(match.robot1Id)) ||
+          (match.robot2Id !== null && userRobotIds.has(match.robot2Id));
+
+        if (hasUserRobot) {
+          expect(classList).toContain('border-blue-500');
+          expect(classList).not.toContain('border-gray-700');
+        } else {
+          expect(classList).toContain('border-gray-700');
+          expect(classList).not.toContain('border-blue-500');
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Feature: tournament-bracket-seeding, Property 4: Bracket renders correct structure
+ *
+ * For any tournament with maxRounds rounds, buildBracketTree SHALL return a map
+ * with exactly maxRounds entries, and for each round r, the number of matches
+ * in that round SHALL equal the number of input matches with round === r.
+ *
+ * **Validates: Requirements 3.1, 3.2**
+ */
+describe('Property 4: Bracket renders correct structure', () => {
+  /**
+   * Arbitrary that generates valid tournament data with 1-7 rounds.
+   * For each round r, generates Math.pow(2, maxRounds - r) matches.
+   */
+  const tournamentDataArb = fc
+    .integer({ min: 1, max: 7 })
+    .chain((maxRounds) => {
+      // Build all matches for a proper single-elimination bracket
+      const allMatches: TournamentMatchWithRobots[] = [];
+      let matchId = 1;
+
+      for (let r = 1; r <= maxRounds; r++) {
+        const matchCount = Math.pow(2, maxRounds - r);
+        for (let m = 1; m <= matchCount; m++) {
+          allMatches.push(
+            makeMatch({
+              id: matchId++,
+              round: r,
+              matchNumber: m,
+            })
+          );
+        }
+      }
+
+      // Shuffle the matches to ensure buildBracketTree handles any order
+      return fc.shuffledSubarray(allMatches, { minLength: allMatches.length, maxLength: allMatches.length })
+        .map((shuffled) => ({ maxRounds, matches: shuffled, expectedCounts: computeExpectedCounts(maxRounds) }));
+    });
+
+  function computeExpectedCounts(maxRounds: number): Map<number, number> {
+    const counts = new Map<number, number>();
+    for (let r = 1; r <= maxRounds; r++) {
+      counts.set(r, Math.pow(2, maxRounds - r));
+    }
+    return counts;
+  }
+
+  it('should produce a map with maxRounds entries, each with the correct match count', () => {
+    fc.assert(
+      fc.property(tournamentDataArb, ({ maxRounds, matches, expectedCounts }) => {
+        const tree = buildBracketTree(matches, maxRounds);
+
+        // The map should have exactly maxRounds entries
+        expect(tree.size).toBe(maxRounds);
+
+        // Each round should have the correct number of matches
+        for (let r = 1; r <= maxRounds; r++) {
+          const roundMatches = tree.get(r);
+          expect(roundMatches).toBeDefined();
+          expect(roundMatches!.length).toBe(expectedCounts.get(r));
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should sort matches within each round by matchNumber ascending', () => {
+    fc.assert(
+      fc.property(tournamentDataArb, ({ maxRounds, matches }) => {
+        const tree = buildBracketTree(matches, maxRounds);
+
+        for (let r = 1; r <= maxRounds; r++) {
+          const roundMatches = tree.get(r)!;
+          for (let i = 1; i < roundMatches.length; i++) {
+            expect(roundMatches[i].matchNumber).toBeGreaterThan(
+              roundMatches[i - 1].matchNumber
+            );
+          }
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/prototype/frontend/src/__tests__/tournament-components.unit.test.tsx
+++ b/prototype/frontend/src/__tests__/tournament-components.unit.test.tsx
@@ -1,0 +1,639 @@
+/**
+ * Unit tests for tournament bracket components — Task 10.2
+ * Feature: tournament-bracket-seeding
+ *
+ * Tests:
+ * - MatchCard: TBD/placeholder, Bye, Pending, Completed states
+ * - MatchCard: Seed number display (yellow, top 32 only)
+ * - MatchCard: User robot highlighting (blue border, ring, YOU badge)
+ * - MatchCard: Dimmed and highlighted states
+ * - TournamentDetailPage: Error + retry, Champion banner, 404 state
+ * - SeedingList: Top 32 limit, click-to-scroll, user robots section
+ * - BracketView: Round filter controls, bot picker dropdown
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { TournamentMatchWithRobots } from '../utils/bracketUtils';
+import type { SeedEntry } from '../utils/tournamentApi';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeMatch(
+  overrides: Partial<TournamentMatchWithRobots> & {
+    id: number;
+    round: number;
+    matchNumber: number;
+  },
+): TournamentMatchWithRobots {
+  return {
+    tournamentId: 1,
+    robot1Id: null,
+    robot2Id: null,
+    winnerId: null,
+    battleId: null,
+    status: 'pending',
+    isByeMatch: false,
+    completedAt: null,
+    robot1: null,
+    robot2: null,
+    winner: null,
+    ...overrides,
+  };
+}
+
+// ══════════════════════════════════════════════════════════════
+//  MatchCard Tests
+// ══════════════════════════════════════════════════════════════
+
+import MatchCard from '../components/tournament/MatchCard';
+
+describe('MatchCard', () => {
+  const emptySeedMap = new Map<number, number>();
+  const emptyUserIds = new Set<number>();
+
+  // ── Placeholder / TBD state ──
+
+  describe('placeholder state (no robots assigned)', () => {
+    it('should render "TBD" for both slots when no robots are assigned', () => {
+      const match = makeMatch({ id: 1, round: 2, matchNumber: 1 });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const tbdElements = container.querySelectorAll('.italic');
+      expect(tbdElements.length).toBe(2);
+      expect(tbdElements[0].textContent).toBe('TBD');
+      expect(tbdElements[1].textContent).toBe('TBD');
+    });
+
+    it('should use gray border for placeholder matches', () => {
+      const match = makeMatch({ id: 2, round: 2, matchNumber: 1 });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-2"]');
+      expect(card?.className).toContain('border-gray-700');
+    });
+  });
+
+  // ── Bye state ──
+
+  describe('bye state', () => {
+    it('should render BYE badge with yellow styling', () => {
+      const match = makeMatch({
+        id: 3, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        isByeMatch: true, status: 'completed', winnerId: 10,
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const byeBadge = screen.getByText('BYE');
+      expect(byeBadge).toBeTruthy();
+      expect(byeBadge.className).toContain('bg-yellow-500/20');
+      expect(byeBadge.className).toContain('text-yellow-400');
+    });
+
+    it('should show the advancing robot name in the first slot', () => {
+      const match = makeMatch({
+        id: 4, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        isByeMatch: true, status: 'completed', winnerId: 10,
+      });
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      expect(screen.getByText('AlphaBot')).toBeTruthy();
+    });
+
+    it('should not render TBD for the second slot in a bye match', () => {
+      const match = makeMatch({
+        id: 5, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        isByeMatch: true, status: 'completed', winnerId: 10,
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      // The second slot should show BYE, not TBD
+      const italicElements = container.querySelectorAll('.italic');
+      const tdbTexts = Array.from(italicElements).filter((el) => el.textContent === 'TBD');
+      expect(tdbTexts.length).toBe(0);
+    });
+
+    it('should use yellow border for bye matches without user robot', () => {
+      const match = makeMatch({
+        id: 6, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        isByeMatch: true, status: 'completed', winnerId: 10,
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-6"]');
+      expect(card?.className).toContain('border-yellow-600/40');
+    });
+  });
+
+  // ── Pending state ──
+
+  describe('pending state (two robots, not yet fought)', () => {
+    it('should render both robot names', () => {
+      const match = makeMatch({
+        id: 7, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      expect(screen.getByText('AlphaBot')).toBeTruthy();
+      expect(screen.getByText('BetaBot')).toBeTruthy();
+    });
+
+    it('should not show any "Pending" text indicator', () => {
+      const match = makeMatch({
+        id: 8, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      expect(screen.queryByText('Pending')).toBeNull();
+    });
+  });
+
+  // ── Completed state ──
+
+  describe('completed state', () => {
+    it('should show winner in green and loser with line-through', () => {
+      const match = makeMatch({
+        id: 9, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'completed', winnerId: 10,
+        winner: { id: 10, name: 'AlphaBot' },
+      });
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const alpha = screen.getByText('AlphaBot');
+      expect(alpha.className).toContain('text-green-400');
+      expect(alpha.className).toContain('font-semibold');
+
+      const beta = screen.getByText('BetaBot');
+      expect(beta.className).toContain('line-through');
+      expect(beta.className).toContain('text-gray-500');
+    });
+  });
+
+  // ── Seed number display ──
+
+  describe('seed number display', () => {
+    it('should render seed number in yellow for seeds ≤ 32', () => {
+      const match = makeMatch({
+        id: 10, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      const seedMap = new Map<number, number>([[10, 1], [20, 16]]);
+      const { container } = render(
+        <MatchCard match={match} seedMap={seedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const seedSpans = container.querySelectorAll('.text-yellow-400.font-mono');
+      expect(seedSpans.length).toBe(2);
+      expect(seedSpans[0].textContent).toBe('#1');
+      expect(seedSpans[1].textContent).toBe('#16');
+    });
+
+    it('should not render seed number for seeds > 32', () => {
+      const match = makeMatch({
+        id: 11, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      const seedMap = new Map<number, number>([[10, 33], [20, 64]]);
+      const { container } = render(
+        <MatchCard match={match} seedMap={seedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const seedSpans = container.querySelectorAll('.text-yellow-400.font-mono');
+      expect(seedSpans.length).toBe(0);
+    });
+  });
+
+  // ── User robot highlighting ──
+
+  describe('user robot highlighting', () => {
+    it('should apply blue border and ring when match contains user robot', () => {
+      const match = makeMatch({
+        id: 12, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      const userIds = new Set([10]);
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={userIds} isUserFuturePath={false} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-12"]');
+      expect(card?.className).toContain('border-blue-500');
+      expect(card?.className).toContain('ring-1');
+      expect(card?.className).toContain('bg-blue-900/20');
+    });
+
+    it('should render YOU badge next to user robot name', () => {
+      const match = makeMatch({
+        id: 13, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      const userIds = new Set([10]);
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={userIds} isUserFuturePath={false} />,
+      );
+      expect(screen.getByText('YOU')).toBeTruthy();
+    });
+
+    it('should render user robot name in blue', () => {
+      const match = makeMatch({
+        id: 14, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+        status: 'pending',
+      });
+      const userIds = new Set([10]);
+      render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={userIds} isUserFuturePath={false} />,
+      );
+      const alpha = screen.getByText('AlphaBot');
+      expect(alpha.className).toContain('text-blue-300');
+    });
+  });
+
+  // ── Dimmed and highlighted states ──
+
+  describe('dimmed and highlighted states', () => {
+    it('should apply opacity-25 when dimmed', () => {
+      const match = makeMatch({
+        id: 15, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds}
+          isUserFuturePath={false} dimmed={true} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-15"]');
+      expect(card?.className).toContain('opacity-25');
+    });
+
+    it('should apply yellow border and ring when highlighted', () => {
+      const match = makeMatch({
+        id: 16, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds}
+          isUserFuturePath={false} highlighted={true} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-16"]');
+      expect(card?.className).toContain('border-yellow-400');
+      expect(card?.className).toContain('ring-2');
+      expect(card?.className).toContain('bg-yellow-900/30');
+    });
+  });
+
+  // ── data attributes for DOM querying ──
+
+  describe('data attributes', () => {
+    it('should set data-robot1-id and data-robot2-id attributes', () => {
+      const match = makeMatch({
+        id: 17, round: 1, matchNumber: 1,
+        robot1Id: 10, robot1: { id: 10, name: 'AlphaBot', elo: 1500 },
+        robot2Id: 20, robot2: { id: 20, name: 'BetaBot', elo: 1400 },
+      });
+      const { container } = render(
+        <MatchCard match={match} seedMap={emptySeedMap} userRobotIds={emptyUserIds} isUserFuturePath={false} />,
+      );
+      const card = container.querySelector('[data-testid="match-card-17"]');
+      expect(card?.getAttribute('data-robot1-id')).toBe('10');
+      expect(card?.getAttribute('data-robot2-id')).toBe('20');
+    });
+  });
+});
+
+
+// ══════════════════════════════════════════════════════════════
+//  SeedingList Tests
+// ══════════════════════════════════════════════════════════════
+
+import SeedingList from '../components/tournament/SeedingList';
+
+describe('SeedingList', () => {
+  const emptyUserIds = new Set<number>();
+
+  function makeSeedEntries(count: number, startSeed = 1): SeedEntry[] {
+    return Array.from({ length: count }, (_, i) => ({
+      seed: startSeed + i,
+      robotId: 100 + i,
+      robotName: `Robot-${startSeed + i}`,
+      elo: 2000 - (startSeed + i) * 10,
+      eliminated: false,
+    }));
+  }
+
+  it('should show "No seeding data available" when seedings array is empty', () => {
+    render(<SeedingList seedings={[]} userRobotIds={emptyUserIds} />);
+    expect(screen.getByText('No seeding data available')).toBeTruthy();
+  });
+
+  it('should default to expanded state', () => {
+    const seedings = makeSeedEntries(5);
+    render(<SeedingList seedings={seedings} userRobotIds={emptyUserIds} />);
+    expect(screen.getByText('Robot-1')).toBeTruthy();
+  });
+
+  it('should only show top 32 seeds, not all entries', () => {
+    // 40 entries: seeds 1-40
+    const seedings = makeSeedEntries(40);
+    render(<SeedingList seedings={seedings} userRobotIds={emptyUserIds} />);
+    // Seed 32 should be visible
+    expect(screen.getByText('Robot-32')).toBeTruthy();
+    // Seed 33+ should NOT be visible (no user robots beyond 32)
+    expect(screen.queryByText('Robot-33')).toBeNull();
+    expect(screen.queryByText('Robot-40')).toBeNull();
+  });
+
+  it('should show user robots beyond top 32 in a separate "Your robots" section', () => {
+    const seedings = makeSeedEntries(40);
+    // User owns robot at seed 35 (robotId = 134)
+    const userIds = new Set([134]);
+    render(<SeedingList seedings={seedings} userRobotIds={userIds} />);
+    expect(screen.getByText('Your robots')).toBeTruthy();
+    expect(screen.getByText('Robot-35')).toBeTruthy();
+  });
+
+  it('should apply blue styling to user-owned robots in top 32', () => {
+    const seedings = makeSeedEntries(10);
+    // User owns robot at seed 3 (robotId = 102)
+    const userIds = new Set([102]);
+    const { container } = render(
+      <SeedingList seedings={seedings} userRobotIds={userIds} />,
+    );
+    // Find the user robot row — it should have border-blue-500
+    const userRow = container.querySelector('.border-blue-500');
+    expect(userRow).not.toBeNull();
+    // Should also show YOU badge
+    expect(screen.getByText('YOU')).toBeTruthy();
+  });
+
+  it('should apply line-through to eliminated robots', () => {
+    const seedings: SeedEntry[] = [
+      { seed: 1, robotId: 1, robotName: 'Winner', elo: 2000, eliminated: false },
+      { seed: 2, robotId: 2, robotName: 'Loser', elo: 1900, eliminated: true },
+    ];
+    render(<SeedingList seedings={seedings} userRobotIds={emptyUserIds} />);
+    const loser = screen.getByText('Loser');
+    expect(loser.className).toContain('line-through');
+  });
+
+  it('should call onRobotClick when a seed entry is clicked', () => {
+    const seedings = makeSeedEntries(3);
+    const handleClick = vi.fn();
+    render(
+      <SeedingList seedings={seedings} userRobotIds={emptyUserIds} onRobotClick={handleClick} />,
+    );
+    fireEvent.click(screen.getByText('Robot-2'));
+    expect(handleClick).toHaveBeenCalledWith(101); // robotId for seed 2
+  });
+
+  it('should collapse and expand when header is clicked', () => {
+    const seedings = makeSeedEntries(3);
+    render(<SeedingList seedings={seedings} userRobotIds={emptyUserIds} />);
+    // Initially expanded
+    expect(screen.getByText('Robot-1')).toBeTruthy();
+    // Click header to collapse
+    fireEvent.click(screen.getByText('Top Seeds'));
+    expect(screen.queryByText('Robot-1')).toBeNull();
+    // Click again to expand
+    fireEvent.click(screen.getByText('Top Seeds'));
+    expect(screen.getByText('Robot-1')).toBeTruthy();
+  });
+
+  it('should display seed numbers in yellow for top 32', () => {
+    const seedings = makeSeedEntries(3);
+    const { container } = render(
+      <SeedingList seedings={seedings} userRobotIds={emptyUserIds} />,
+    );
+    const seedNumbers = container.querySelectorAll('.text-yellow-400.font-mono');
+    expect(seedNumbers.length).toBe(3);
+    expect(seedNumbers[0].textContent).toBe('#1');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+//  TournamentDetailPage Tests
+// ══════════════════════════════════════════════════════════════
+
+// Mock modules before importing the component
+vi.mock('../utils/tournamentApi', () => ({
+  getTournamentDetails: vi.fn(),
+}));
+
+vi.mock('../utils/robotApi', () => ({
+  fetchMyRobots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn().mockReturnValue({
+    user: { id: 1, username: 'testuser', email: 'test@example.com', role: 'player', currency: 1000, prestige: 0 },
+    token: 'mock-token',
+    logout: vi.fn(),
+    login: vi.fn(),
+    loading: false,
+    refreshUser: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/Navigation', () => ({
+  default: () => React.createElement('nav', { 'data-testid': 'nav' }, 'Nav'),
+}));
+
+import TournamentDetailPage from '../pages/TournamentDetailPage';
+import { getTournamentDetails } from '../utils/tournamentApi';
+
+const mockGetTournamentDetails = vi.mocked(getTournamentDetails);
+
+function renderDetailPage(tournamentId = '1'): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[`/tournaments/${tournamentId}`]}>
+      <Routes>
+        <Route path="/tournaments/:id" element={<TournamentDetailPage />} />
+        <Route path="/tournaments" element={<div data-testid="tournaments-list">List</div>} />
+        <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('TournamentDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show error message and retry button on API failure', async () => {
+    mockGetTournamentDetails.mockRejectedValueOnce(new Error('Network error'));
+
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load tournament details')).toBeTruthy();
+    });
+
+    // Retry button should be present
+    const retryButton = screen.getByText('Retry');
+    expect(retryButton).toBeTruthy();
+
+    // Back to Tournaments link should be present
+    expect(screen.getByText('Back to Tournaments')).toBeTruthy();
+  });
+
+  it('should show "Tournament not found" on 404 response', async () => {
+    mockGetTournamentDetails.mockRejectedValueOnce({
+      response: { status: 404 },
+    });
+
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Tournament not found')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Back to Tournaments')).toBeTruthy();
+  });
+
+  it('should show champion banner when tournament is completed with a winner', async () => {
+    mockGetTournamentDetails.mockResolvedValueOnce({
+      tournament: {
+        id: 1,
+        name: 'Test Tournament',
+        type: 'single_elimination',
+        status: 'completed',
+        currentRound: 3,
+        maxRounds: 3,
+        totalParticipants: 8,
+        winnerId: 10,
+        startedAt: '2026-01-01',
+        completedAt: '2026-01-02',
+        createdAt: '2026-01-01',
+        winner: { id: 10, name: 'ChampionBot' },
+        matches: [],
+        currentRoundMatches: [],
+        participantCount: 8,
+        seedings: [],
+      },
+      seedings: [],
+    });
+
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Champion:.*ChampionBot/)).toBeTruthy();
+    });
+
+    expect(screen.getByText('🏆')).toBeTruthy();
+    expect(screen.getByText('Tournament Winner')).toBeTruthy();
+  });
+
+  it('should retry fetching when retry button is clicked after error', async () => {
+    // First call fails
+    mockGetTournamentDetails.mockRejectedValueOnce(new Error('Network error'));
+
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load tournament details')).toBeTruthy();
+    });
+
+    // Second call succeeds
+    mockGetTournamentDetails.mockResolvedValueOnce({
+      tournament: {
+        id: 1,
+        name: 'Recovered Tournament',
+        type: 'single_elimination',
+        status: 'active',
+        currentRound: 1,
+        maxRounds: 3,
+        totalParticipants: 8,
+        winnerId: null,
+        startedAt: '2026-01-01',
+        completedAt: null,
+        createdAt: '2026-01-01',
+        matches: [],
+        currentRoundMatches: [],
+        participantCount: 8,
+        seedings: [],
+      },
+      seedings: [],
+    });
+
+    fireEvent.click(screen.getByText('Retry'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Recovered Tournament')).toBeTruthy();
+    });
+  });
+
+  it('should display tournament header info (name, status, round, participants)', async () => {
+    mockGetTournamentDetails.mockResolvedValueOnce({
+      tournament: {
+        id: 1,
+        name: 'Grand Championship',
+        type: 'single_elimination',
+        status: 'active',
+        currentRound: 2,
+        maxRounds: 4,
+        totalParticipants: 16,
+        winnerId: null,
+        startedAt: '2026-01-01',
+        completedAt: null,
+        createdAt: '2026-01-01',
+        matches: [],
+        currentRoundMatches: [],
+        participantCount: 16,
+        seedings: [],
+      },
+      seedings: [],
+    });
+
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Grand Championship')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Active')).toBeTruthy();
+    expect(screen.getByText(/Round 2 \/ 4/)).toBeTruthy();
+    expect(screen.getByText(/16 participants/)).toBeTruthy();
+  });
+
+  it('should show loading skeleton initially', () => {
+    // Never resolve — keep it loading
+    mockGetTournamentDetails.mockReturnValue(new Promise(() => {}));
+
+    const { container } = renderDetailPage();
+
+    // Should have the animate-pulse skeleton
+    const skeleton = container.querySelector('.animate-pulse');
+    expect(skeleton).not.toBeNull();
+  });
+});

--- a/prototype/frontend/src/components/tournament/BracketView.tsx
+++ b/prototype/frontend/src/components/tournament/BracketView.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo, useState, useCallback } from 'react';
+import { TournamentMatchWithRobots, getUserFuturePath, getRoundLabel } from '../../utils/bracketUtils';
+import { useIsMobile } from '../../hooks/useMediaQuery';
+import type { SeedEntry } from '../../utils/tournamentApi';
+import DesktopBracket from './DesktopBracket';
+import MobileBracket from './MobileBracket';
+import SeedingList from './SeedingList';
+
+interface BracketViewProps {
+  matches: TournamentMatchWithRobots[];
+  seedings: SeedEntry[];
+  maxRounds: number;
+  currentRound: number;
+  status: string;
+  userRobotIds: Set<number>;
+}
+
+const BracketView: React.FC<BracketViewProps> = ({
+  matches, seedings, maxRounds, currentRound, status, userRobotIds,
+}) => {
+  const isMobile = useIsMobile();
+  const [focusRobotId, setFocusRobotId] = useState<number | null>(null);
+  const [showOnlyMyBots, setShowOnlyMyBots] = useState(false);
+  const [startRound, setStartRound] = useState(1);
+  const [endRound, setEndRound] = useState(maxRounds);
+
+  const seedMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const entry of seedings) map.set(entry.robotId, entry.seed);
+    return map;
+  }, [seedings]);
+
+  const futurePathMatchIds = useMemo(
+    () => getUserFuturePath(matches, userRobotIds, maxRounds),
+    [matches, userRobotIds, maxRounds],
+  );
+
+  /** Find all user robots that appear in this tournament's matches */
+  const userRobotsInTournament = useMemo(() => {
+    const robots: Array<{ id: number; name: string }> = [];
+    const seen = new Set<number>();
+    for (const m of matches) {
+      if (m.robot1Id !== null && userRobotIds.has(m.robot1Id) && !seen.has(m.robot1Id) && m.robot1) {
+        seen.add(m.robot1Id);
+        robots.push({ id: m.robot1.id, name: m.robot1.name });
+      }
+      if (m.robot2Id !== null && userRobotIds.has(m.robot2Id) && !seen.has(m.robot2Id) && m.robot2) {
+        seen.add(m.robot2Id);
+        robots.push({ id: m.robot2.id, name: m.robot2.name });
+      }
+    }
+    return robots;
+  }, [matches, userRobotIds]);
+
+  const handleRobotFocus = useCallback((robotId: number) => {
+    setFocusRobotId(null);
+    setTimeout(() => setFocusRobotId(robotId), 0);
+  }, []);
+
+  const handleMyBotSelect = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    if (val === '') {
+      setShowOnlyMyBots(false);
+      setFocusRobotId(null);
+    } else {
+      const robotId = parseInt(val, 10);
+      setShowOnlyMyBots(true);
+      handleRobotFocus(robotId);
+    }
+  }, [handleRobotFocus]);
+
+  if (matches.length === 0) {
+    return (
+      <div className="bg-gray-800 rounded-lg border border-gray-700 p-8 text-center">
+        <p className="text-gray-500">No matches available</p>
+      </div>
+    );
+  }
+
+  const roundOptions = Array.from({ length: maxRounds }, (_, i) => i + 1);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* My Bots picker */}
+        {userRobotsInTournament.length > 0 && (
+          <select
+            onChange={handleMyBotSelect}
+            defaultValue=""
+            className="bg-gray-800 border border-gray-700 text-sm text-gray-300 rounded px-3 py-1.5 hover:border-gray-500 focus:border-blue-500 focus:outline-none"
+          >
+            <option value="">All matches</option>
+            {userRobotsInTournament.map((r) => (
+              <option key={r.id} value={r.id}>🤖 {r.name}</option>
+            ))}
+          </select>
+        )}
+
+        {/* Round range filter */}
+        {!isMobile && maxRounds > 2 && (
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <span>From</span>
+            <select
+              value={startRound}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10);
+                setStartRound(v);
+                if (v > endRound) setEndRound(v);
+              }}
+              className="bg-gray-800 border border-gray-700 text-gray-300 rounded px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
+            >
+              {roundOptions.map((r) => (
+                <option key={r} value={r}>{getRoundLabel(r, maxRounds)}</option>
+              ))}
+            </select>
+            <span>to</span>
+            <select
+              value={endRound}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10);
+                setEndRound(v);
+                if (v < startRound) setStartRound(v);
+              }}
+              className="bg-gray-800 border border-gray-700 text-gray-300 rounded px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
+            >
+              {roundOptions.filter((r) => r >= startRound).map((r) => (
+                <option key={r} value={r}>{getRoundLabel(r, maxRounds)}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="flex-1 min-w-0">
+          {isMobile ? (
+            <MobileBracket
+              matches={matches} maxRounds={maxRounds} currentRound={currentRound}
+              status={status} seedMap={seedMap} userRobotIds={userRobotIds}
+              futurePathMatchIds={futurePathMatchIds}
+            />
+          ) : (
+            <DesktopBracket
+              matches={matches} maxRounds={maxRounds} currentRound={currentRound}
+              status={status} seedMap={seedMap} userRobotIds={userRobotIds}
+              futurePathMatchIds={futurePathMatchIds} focusRobotId={focusRobotId}
+              showOnlyMyBots={showOnlyMyBots}
+              startRound={startRound} endRound={endRound}
+            />
+          )}
+        </div>
+        <div className="lg:w-64 shrink-0">
+          <SeedingList seedings={seedings} userRobotIds={userRobotIds}
+            onRobotClick={handleRobotFocus} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BracketView;

--- a/prototype/frontend/src/components/tournament/DesktopBracket.tsx
+++ b/prototype/frontend/src/components/tournament/DesktopBracket.tsx
@@ -1,0 +1,139 @@
+import React, { useRef, useState, useCallback, useEffect } from 'react';
+import { TournamentMatchWithRobots, getRoundLabel } from '../../utils/bracketUtils';
+import { useBracketLayout, CARD_HEIGHT, COLUMN_GAP, COLUMN_WIDTH, LABEL_HEIGHT } from '../../hooks/useBracketLayout';
+import { useZoomPan } from '../../hooks/useZoomPan';
+import MatchCard from './MatchCard';
+
+interface DesktopBracketProps {
+  matches: TournamentMatchWithRobots[];
+  maxRounds: number;
+  currentRound: number;
+  status: string;
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  futurePathMatchIds: Set<number>;
+  focusRobotId: number | null;
+  showOnlyMyBots: boolean;
+  startRound: number;
+  endRound: number;
+}
+
+const DesktopBracket: React.FC<DesktopBracketProps> = ({
+  matches, maxRounds, currentRound, status, seedMap,
+  userRobotIds, futurePathMatchIds, focusRobotId, showOnlyMyBots,
+  startRound, endRound,
+}) => {
+  const {
+    bracketTree, visibleRounds, matchPositions,
+    visibleHeight, totalWidth, connectorLines,
+  } = useBracketLayout(matches, maxRounds, startRound, endRound);
+
+  const zp = useZoomPan([startRound, endRound]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [highlightedMatchId, setHighlightedMatchId] = useState<number | null>(null);
+
+  // Scroll to focused robot
+  useEffect(() => {
+    if (focusRobotId === null || !containerRef.current) return;
+    const card = containerRef.current.querySelector(
+      `[data-robot1-id="${focusRobotId}"], [data-robot2-id="${focusRobotId}"]`
+    ) as HTMLElement | null;
+    if (!card) return;
+    const testId = card.getAttribute('data-testid') ?? '';
+    const matchId = parseInt(testId.replace('match-card-', ''), 10);
+    card.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+    setHighlightedMatchId(matchId);
+    const timer = setTimeout(() => setHighlightedMatchId(null), 2000);
+    return () => clearTimeout(timer);
+  }, [focusRobotId]);
+
+  const isUserRelated = useCallback((match: TournamentMatchWithRobots): boolean => {
+    return (
+      (match.robot1Id !== null && userRobotIds.has(match.robot1Id)) ||
+      (match.robot2Id !== null && userRobotIds.has(match.robot2Id)) ||
+      futurePathMatchIds.has(match.id)
+    );
+  }, [userRobotIds, futurePathMatchIds]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="desktop-bracket"
+      className="overflow-auto relative bg-gray-900 rounded-lg border border-gray-700"
+      style={{
+        maxHeight: '80vh',
+        cursor: zp.isPanning ? 'grabbing' : 'grab',
+      }}
+      onWheel={zp.handleWheel}
+      onMouseDown={zp.handleMouseDown}
+      onMouseMove={zp.handleMouseMove}
+      onMouseUp={zp.handleMouseUp}
+      onMouseLeave={zp.handleMouseUp}
+      onTouchMove={zp.handleTouchMove}
+      onTouchEnd={zp.handleTouchEnd}
+    >
+      {/* Zoom controls */}
+      <div className="sticky top-0 left-0 z-10 flex items-center gap-2 p-2 bg-gray-900/90 backdrop-blur-sm text-xs text-gray-400">
+        <button className="px-2 py-0.5 bg-gray-700 rounded hover:bg-gray-600" onClick={zp.zoomOut}>−</button>
+        <span>{Math.round(zp.scale * 100)}%</span>
+        <button className="px-2 py-0.5 bg-gray-700 rounded hover:bg-gray-600" onClick={zp.zoomIn}>+</button>
+        <button className="px-2 py-0.5 bg-gray-700 rounded hover:bg-gray-600 ml-2" onClick={zp.reset}>Reset</button>
+        <span className="ml-2 text-gray-500">Ctrl+scroll to zoom · Drag to pan</span>
+      </div>
+
+      <div
+        className="relative p-3"
+        style={{
+          width: `${totalWidth}px`,
+          height: `${visibleHeight + LABEL_HEIGHT}px`,
+          transform: `scale(${zp.scale}) translate(${zp.translate.x / zp.scale}px, ${zp.translate.y / zp.scale}px)`,
+          transformOrigin: 'top left',
+        }}
+      >
+        <svg className="absolute inset-0 pointer-events-none"
+          width={totalWidth} height={visibleHeight + LABEL_HEIGHT}>
+          {connectorLines}
+        </svg>
+
+        {visibleRounds.map((round, vi) => {
+          const roundMatches = bracketTree.get(round) ?? [];
+          const isCurrentRound = status === 'active' && round === currentRound;
+          const x = vi * (COLUMN_WIDTH + COLUMN_GAP) + 12;
+
+          return (
+            <React.Fragment key={round}>
+              <div
+                className={`absolute text-xs font-semibold text-center py-1 ${
+                  isCurrentRound ? 'text-yellow-400' : 'text-gray-400'
+                }`}
+                style={{ left: `${x}px`, top: 0, width: `${COLUMN_WIDTH}px` }}
+              >
+                {getRoundLabel(round, maxRounds)}
+              </div>
+
+              {roundMatches.map((match) => {
+                const yCenter = matchPositions.get(match.id) ?? 0;
+                const yTop = yCenter - CARD_HEIGHT / 2 + LABEL_HEIGHT;
+                const isDimmed = showOnlyMyBots && !isUserRelated(match);
+
+                return (
+                  <div key={match.id} className="absolute"
+                    style={{ left: `${x}px`, top: `${yTop}px` }}>
+                    <MatchCard
+                      match={match} seedMap={seedMap} userRobotIds={userRobotIds}
+                      isUserFuturePath={futurePathMatchIds.has(match.id)}
+                      dimmed={isDimmed} highlighted={highlightedMatchId === match.id}
+                    />
+                  </div>
+                );
+              })}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default DesktopBracket;

--- a/prototype/frontend/src/components/tournament/MatchCard.tsx
+++ b/prototype/frontend/src/components/tournament/MatchCard.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { TournamentMatchWithRobots } from '../../utils/bracketUtils';
+
+interface MatchCardProps {
+  match: TournamentMatchWithRobots;
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  isUserFuturePath: boolean;
+  dimmed?: boolean;
+  highlighted?: boolean;
+}
+
+function getMatchState(match: TournamentMatchWithRobots): 'completed' | 'bye' | 'pending' | 'placeholder' {
+  if (match.isByeMatch) return 'bye';
+  if (match.status === 'completed' && match.winnerId !== null) return 'completed';
+  if (match.robot1 !== null && match.robot2 !== null) return 'pending';
+  return 'placeholder';
+}
+
+/**
+ * Renders a robot slot. Seed number is rendered as a separate colored span
+ * so it visually stands out from the robot name.
+ */
+function RobotSlot({
+  robot,
+  seed,
+  isWinner,
+  isLoser,
+  isUserRobot,
+}: {
+  robot: { id: number; name: string } | null;
+  seed: number | undefined;
+  isWinner: boolean;
+  isLoser: boolean;
+  isUserRobot: boolean;
+}): React.ReactElement {
+  if (!robot) {
+    return <span className="text-gray-600 italic text-xs">TBD</span>;
+  }
+
+  let nameClass = 'text-gray-300';
+  if (isWinner) nameClass = 'text-green-400 font-semibold';
+  else if (isLoser) nameClass = 'text-gray-500 line-through';
+  else if (isUserRobot) nameClass = 'text-blue-300 font-medium';
+
+  const showSeed = seed !== undefined && seed <= 32;
+
+  return (
+    <span className="text-xs truncate max-w-[130px] flex items-center gap-1">
+      {showSeed && (
+        <span className="text-yellow-400 font-mono font-semibold shrink-0">#{seed}</span>
+      )}
+      <span className={nameClass + ' truncate'}>{robot.name}</span>
+    </span>
+  );
+}
+
+const MatchCard: React.FC<MatchCardProps> = ({
+  match, seedMap, userRobotIds, isUserFuturePath, dimmed, highlighted,
+}) => {
+  const matchState = getMatchState(match);
+  const isRobot1User = match.robot1Id !== null && userRobotIds.has(match.robot1Id);
+  const isRobot2User = match.robot2Id !== null && userRobotIds.has(match.robot2Id);
+  const hasUserRobot = isRobot1User || isRobot2User;
+
+  let borderClass = 'border-gray-700';
+  let bgClass = 'bg-gray-800';
+  if (hasUserRobot) { borderClass = 'border-blue-500'; bgClass = 'bg-blue-900/20'; }
+  else if (isUserFuturePath) { borderClass = 'border-blue-500/30'; }
+  if (matchState === 'bye' && !hasUserRobot) { borderClass = 'border-yellow-600/40'; }
+  if (highlighted) { borderClass = 'border-yellow-400'; bgClass = 'bg-yellow-900/30'; }
+
+  const robot1Seed = match.robot1Id !== null ? seedMap.get(match.robot1Id) : undefined;
+  const robot2Seed = match.robot2Id !== null ? seedMap.get(match.robot2Id) : undefined;
+
+  const isByeMatch = matchState === 'bye';
+  const isR1Win = isByeMatch ? true : match.status === 'completed' && match.winnerId === match.robot1Id;
+  const isR2Win = !isByeMatch && match.status === 'completed' && match.winnerId === match.robot2Id;
+  const isR1Loss = !isByeMatch && match.status === 'completed' && !isR1Win && match.robot1 !== null;
+  const isR2Loss = !isByeMatch && match.status === 'completed' && !isR2Win && match.robot2 !== null;
+
+  return (
+    <div
+      data-testid={`match-card-${match.id}`}
+      data-robot1-id={match.robot1Id ?? undefined}
+      data-robot2-id={match.robot2Id ?? undefined}
+      className={`${bgClass} border ${borderClass} rounded px-2 py-1.5 w-44 transition-opacity duration-200 ${
+        hasUserRobot ? 'ring-1 ring-blue-500/50 shadow-md shadow-blue-500/10' : ''
+      } ${highlighted ? 'ring-2 ring-yellow-400/70' : ''} ${dimmed ? 'opacity-25' : ''}`}
+    >
+      <div className="flex items-center justify-between gap-1">
+        <RobotSlot robot={match.robot1} seed={robot1Seed}
+          isWinner={isR1Win} isLoser={isR1Loss} isUserRobot={isRobot1User} />
+        {isRobot1User && <span className="text-[9px] text-blue-400 font-medium shrink-0">YOU</span>}
+      </div>
+      <div className="border-t border-gray-700/50 my-0.5" />
+      <div className="flex items-center justify-between gap-1">
+        {isByeMatch ? (
+          <span className="text-xs font-bold px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">BYE</span>
+        ) : (
+          <>
+            <RobotSlot robot={match.robot2} seed={robot2Seed}
+              isWinner={isR2Win} isLoser={isR2Loss} isUserRobot={isRobot2User} />
+            {isRobot2User && <span className="text-[9px] text-blue-400 font-medium shrink-0">YOU</span>}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MatchCard;

--- a/prototype/frontend/src/components/tournament/MobileBracket.tsx
+++ b/prototype/frontend/src/components/tournament/MobileBracket.tsx
@@ -1,0 +1,349 @@
+import React, { useState, useMemo } from 'react';
+import {
+  TournamentMatchWithRobots,
+  getRoundLabel,
+  buildBracketTree,
+} from '../../utils/bracketUtils';
+import MatchCard from './MatchCard';
+
+interface MobileBracketProps {
+  matches: TournamentMatchWithRobots[];
+  maxRounds: number;
+  currentRound: number;
+  status: string;
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  futurePathMatchIds: Set<number>;
+}
+
+type ViewMode = 'myPath' | 'roundList';
+
+/**
+ * Mobile-optimised bracket view with two modes:
+ * - "My Path": vertical timeline of the user's matches + future path
+ * - "Round List": one round at a time with prev/next navigation
+ *
+ * Validates: Requirements 9.1, 9.2, 9.3, 9.4, 9.6
+ */
+const MobileBracket: React.FC<MobileBracketProps> = ({
+  matches,
+  maxRounds,
+  currentRound,
+  status,
+  seedMap,
+  userRobotIds,
+  futurePathMatchIds,
+}) => {
+  const hasUserRobot = userRobotIds.size > 0;
+
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    hasUserRobot ? 'myPath' : 'roundList',
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* View mode toggle */}
+      <div className="flex rounded-lg overflow-hidden border border-gray-700">
+        <button
+          className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            viewMode === 'myPath'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-800 text-gray-400 hover:text-gray-200'
+          }`}
+          onClick={() => setViewMode('myPath')}
+        >
+          My Path
+        </button>
+        <button
+          className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            viewMode === 'roundList'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-800 text-gray-400 hover:text-gray-200'
+          }`}
+          onClick={() => setViewMode('roundList')}
+        >
+          Round List
+        </button>
+      </div>
+
+      {viewMode === 'myPath' ? (
+        <MyPathView
+          matches={matches}
+          maxRounds={maxRounds}
+          seedMap={seedMap}
+          userRobotIds={userRobotIds}
+          futurePathMatchIds={futurePathMatchIds}
+        />
+      ) : (
+        <RoundListView
+          matches={matches}
+          maxRounds={maxRounds}
+          currentRound={currentRound}
+          status={status}
+          seedMap={seedMap}
+          userRobotIds={userRobotIds}
+          futurePathMatchIds={futurePathMatchIds}
+        />
+      )}
+    </div>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  My Path View                                                       */
+/* ------------------------------------------------------------------ */
+
+interface MyPathViewProps {
+  matches: TournamentMatchWithRobots[];
+  maxRounds: number;
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  futurePathMatchIds: Set<number>;
+}
+
+/**
+ * Shows only matches involving the user's robot(s) plus connected
+ * future-path matches, rendered as a vertical timeline grouped by round.
+ *
+ * Validates: Requirement 9.2
+ */
+const MyPathView: React.FC<MyPathViewProps> = ({
+  matches,
+  maxRounds,
+  seedMap,
+  userRobotIds,
+  futurePathMatchIds,
+}) => {
+  const pathMatches = useMemo(() => {
+    const filtered = matches.filter((m) => {
+      const hasUser =
+        (m.robot1Id !== null && userRobotIds.has(m.robot1Id)) ||
+        (m.robot2Id !== null && userRobotIds.has(m.robot2Id));
+      return hasUser || futurePathMatchIds.has(m.id);
+    });
+    // Sort by round ascending, then matchNumber ascending
+    return filtered.sort(
+      (a, b) => a.round - b.round || a.matchNumber - b.matchNumber,
+    );
+  }, [matches, userRobotIds, futurePathMatchIds]);
+
+  if (pathMatches.length === 0) {
+    return (
+      <div className="bg-gray-800 rounded-lg border border-gray-700 p-6 text-center">
+        <p className="text-gray-500 text-sm">
+          No matches found for your robots. Switch to Round List to browse all matches.
+        </p>
+      </div>
+    );
+  }
+
+  // Group by round for dividers
+  let lastRound = -1;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {pathMatches.map((match) => {
+        const showRoundLabel = match.round !== lastRound;
+        lastRound = match.round;
+
+        return (
+          <React.Fragment key={match.id}>
+            {showRoundLabel && (
+              <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide pt-2 pb-1 border-b border-gray-700/50">
+                {getRoundLabel(match.round, maxRounds)}
+              </div>
+            )}
+            <MatchCard
+              match={match}
+              seedMap={seedMap}
+              userRobotIds={userRobotIds}
+              isUserFuturePath={futurePathMatchIds.has(match.id)}
+            />
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  Round List View                                                    */
+/* ------------------------------------------------------------------ */
+
+interface RoundListViewProps {
+  matches: TournamentMatchWithRobots[];
+  maxRounds: number;
+  currentRound: number;
+  status: string;
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  futurePathMatchIds: Set<number>;
+}
+
+/**
+ * Displays one round at a time with prev/next navigation.
+ * Each round section is collapsible.
+ *
+ * Validates: Requirements 9.3, 9.6
+ */
+const RoundListView: React.FC<RoundListViewProps> = ({
+  matches,
+  maxRounds,
+  currentRound,
+  status,
+  seedMap,
+  userRobotIds,
+  futurePathMatchIds,
+}) => {
+  const [selectedRound, setSelectedRound] = useState<number>(currentRound);
+  const [collapsedRounds, setCollapsedRounds] = useState<Set<number>>(
+    new Set(),
+  );
+
+  const bracketTree = useMemo(
+    () => buildBracketTree(matches, maxRounds),
+    [matches, maxRounds],
+  );
+
+  const roundMatches = bracketTree.get(selectedRound) ?? [];
+  const isCurrentRound = status === 'active' && selectedRound === currentRound;
+
+  const toggleCollapse = (round: number): void => {
+    setCollapsedRounds((prev) => {
+      const next = new Set(prev);
+      if (next.has(round)) {
+        next.delete(round);
+      } else {
+        next.add(round);
+      }
+      return next;
+    });
+  };
+
+  const isCollapsed = collapsedRounds.has(selectedRound);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Round navigation */}
+      <div className="flex items-center justify-between bg-gray-800 rounded-lg border border-gray-700 px-3 py-2">
+        <button
+          className="text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed p-1"
+          disabled={selectedRound <= 1}
+          onClick={() => setSelectedRound((r) => Math.max(1, r - 1))}
+          aria-label="Previous round"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+
+        <button
+          className="flex items-center gap-2 text-sm font-medium"
+          onClick={() => toggleCollapse(selectedRound)}
+        >
+          <span
+            className={
+              isCurrentRound ? 'text-blue-400' : 'text-gray-200'
+            }
+          >
+            {getRoundLabel(selectedRound, maxRounds)}
+          </span>
+          {isCurrentRound && (
+            <span className="text-[10px] bg-blue-600/30 text-blue-400 px-1.5 py-0.5 rounded">
+              Current
+            </span>
+          )}
+          <svg
+            className={`w-4 h-4 text-gray-500 transition-transform ${
+              isCollapsed ? '' : 'rotate-180'
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <button
+          className="text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed p-1"
+          disabled={selectedRound >= maxRounds}
+          onClick={() =>
+            setSelectedRound((r) => Math.min(maxRounds, r + 1))
+          }
+          aria-label="Next round"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Round matches */}
+      {!isCollapsed && (
+        <div className="flex flex-col gap-2">
+          {roundMatches.length === 0 ? (
+            <p className="text-gray-500 text-sm text-center py-4">
+              No matches in this round
+            </p>
+          ) : (
+            roundMatches.map((match) => (
+              <MatchCard
+                key={match.id}
+                match={match}
+                seedMap={seedMap}
+                userRobotIds={userRobotIds}
+                isUserFuturePath={futurePathMatchIds.has(match.id)}
+              />
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Round indicator dots */}
+      <div className="flex justify-center gap-1.5 pt-1">
+        {Array.from({ length: maxRounds }, (_, i) => i + 1).map((round) => (
+          <button
+            key={round}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              round === selectedRound
+                ? 'bg-blue-500'
+                : round === currentRound && status === 'active'
+                  ? 'bg-blue-500/40'
+                  : 'bg-gray-600'
+            }`}
+            onClick={() => setSelectedRound(round)}
+            aria-label={`Go to ${getRoundLabel(round, maxRounds)}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MobileBracket;

--- a/prototype/frontend/src/components/tournament/RoundColumn.tsx
+++ b/prototype/frontend/src/components/tournament/RoundColumn.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { TournamentMatchWithRobots, getRoundLabel } from '../../utils/bracketUtils';
+import MatchCard from './MatchCard';
+
+interface RoundColumnProps {
+  round: number;
+  maxRounds: number;
+  matches: TournamentMatchWithRobots[];
+  seedMap: Map<number, number>;
+  userRobotIds: Set<number>;
+  futurePathMatchIds: Set<number>;
+  isCurrentRound: boolean;
+}
+
+/**
+ * Renders a single round column in the bracket view.
+ * Contains a round label and vertically-spaced MatchCard components.
+ * Spacing grows exponentially per round so that round N+1 matches
+ * align between their two feeder matches from round N.
+ *
+ * Validates: Requirements 7.1, 7.2, 3.2
+ */
+const RoundColumn: React.FC<RoundColumnProps> = ({
+  round,
+  maxRounds,
+  matches,
+  seedMap,
+  userRobotIds,
+  futurePathMatchIds,
+  isCurrentRound,
+}) => {
+  const label = getRoundLabel(round, maxRounds);
+
+  // Exponential spacing: round 1 = base, round 2 = 2x, round N = 2^(N-1)x
+  // We use padding/gap to push later-round cards so they center between feeders.
+  const spacingMultiplier = Math.pow(2, round - 1);
+  const baseGap = 8; // px — gap between cards in round 1
+  const gap = baseGap * spacingMultiplier;
+
+  // Top padding offsets later rounds so the first card centers between its two feeders.
+  // Round 1: 0, Round 2: half a card+gap, etc.
+  const topPadding = round === 1 ? 0 : (gap - baseGap) / 2;
+
+  const columnClass = isCurrentRound
+    ? 'border-l-2 border-yellow-500 bg-yellow-900/10'
+    : '';
+
+  return (
+    <div
+      data-testid={`round-column-${round}`}
+      className={`flex flex-col items-center min-w-[11rem] ${columnClass}`}
+    >
+      <div className="text-sm font-semibold text-gray-300 text-center mb-2 px-2">
+        {label}
+      </div>
+      <div
+        className="flex flex-col items-center"
+        style={{ gap: `${gap}px`, paddingTop: `${topPadding}px` }}
+      >
+        {matches.map((match) => (
+          <MatchCard
+            key={match.id}
+            match={match}
+            seedMap={seedMap}
+            userRobotIds={userRobotIds}
+            isUserFuturePath={futurePathMatchIds.has(match.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RoundColumn;

--- a/prototype/frontend/src/components/tournament/SeedingList.tsx
+++ b/prototype/frontend/src/components/tournament/SeedingList.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import type { SeedEntry } from '../../utils/tournamentApi';
+
+interface SeedingListProps {
+  seedings: SeedEntry[];
+  userRobotIds: Set<number>;
+  /** Called when a seed entry is clicked — scrolls bracket to that robot */
+  onRobotClick?: (robotId: number) => void;
+}
+
+/**
+ * Collapsible side panel listing the top 32 seeded tournament participants.
+ * Clicking an entry scrolls the bracket to that robot's match.
+ * User's robots beyond top 32 are shown in a separate section.
+ *
+ * Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6
+ */
+const SeedingList: React.FC<SeedingListProps> = ({ seedings, userRobotIds, onRobotClick }) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(true);
+
+  const top32 = seedings.filter((s) => s.seed <= 32);
+  const userSeedings = seedings.filter((s) => userRobotIds.has(s.robotId) && s.seed > 32);
+
+  const handleClick = (robotId: number): void => {
+    onRobotClick?.(robotId);
+  };
+
+  return (
+    <div className="bg-gray-800 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-700 hover:bg-gray-600 transition-colors"
+        aria-expanded={isExpanded}
+        aria-controls="seeding-list-content"
+      >
+        <span className="text-sm font-semibold text-white">Top Seeds</span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isExpanded && (
+        <ul id="seeding-list-content" className="divide-y divide-gray-700/50 max-h-96 overflow-y-auto">
+          {top32.length === 0 && (
+            <li className="px-4 py-3 text-sm text-gray-500 text-center">
+              No seeding data available
+            </li>
+          )}
+          {top32.map((entry) => (
+            <SeedRow
+              key={entry.robotId}
+              entry={entry}
+              isUserRobot={userRobotIds.has(entry.robotId)}
+              onClick={() => handleClick(entry.robotId)}
+            />
+          ))}
+
+          {userSeedings.length > 0 && (
+            <>
+              <li className="px-4 py-1.5 text-[10px] text-gray-500 uppercase tracking-wider bg-gray-900/50">
+                Your robots
+              </li>
+              {userSeedings.map((entry) => (
+                <SeedRow
+                  key={entry.robotId}
+                  entry={entry}
+                  isUserRobot={true}
+                  onClick={() => handleClick(entry.robotId)}
+                />
+              ))}
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+/** Single seed row — clickable to scroll bracket to that robot */
+function SeedRow({
+  entry,
+  isUserRobot,
+  onClick,
+}: {
+  entry: SeedEntry;
+  isUserRobot: boolean;
+  onClick: () => void;
+}): React.ReactElement {
+  const isEliminated = entry.eliminated;
+
+  return (
+    <li
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
+      className={`px-4 py-2 flex items-center gap-2 text-sm cursor-pointer hover:bg-gray-700/50 transition-colors ${
+        isUserRobot ? 'border-l-2 border-blue-500 bg-blue-900/20' : ''
+      } ${isEliminated ? 'opacity-50' : ''}`}
+    >
+      <span className={`font-mono text-xs shrink-0 w-6 text-right ${
+        isEliminated ? 'text-gray-600' : entry.seed <= 32 ? 'text-yellow-400' : 'text-gray-500'
+      }`}>
+        #{entry.seed}
+      </span>
+      <span className={`truncate ${
+        isEliminated ? 'text-gray-500 line-through' : isUserRobot ? 'text-blue-300' : 'text-white'
+      }`}>
+        {entry.robotName}
+      </span>
+      <span className={`ml-auto text-xs shrink-0 ${isEliminated ? 'text-gray-600' : 'text-gray-400'}`}>
+        {entry.elo}
+      </span>
+      {isUserRobot && (
+        <span className="text-[9px] text-blue-400 font-medium shrink-0">YOU</span>
+      )}
+    </li>
+  );
+}
+
+export default SeedingList;

--- a/prototype/frontend/src/hooks/useBracketLayout.ts
+++ b/prototype/frontend/src/hooks/useBracketLayout.ts
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import React from 'react';
+import { TournamentMatchWithRobots, buildBracketTree } from '../utils/bracketUtils';
+
+const CARD_HEIGHT = 48;
+const BASE_GAP = 12;
+const COLUMN_GAP = 56;
+const COLUMN_WIDTH = 184;
+const LABEL_HEIGHT = 32;
+
+export { CARD_HEIGHT, BASE_GAP, COLUMN_GAP, COLUMN_WIDTH, LABEL_HEIGHT };
+
+interface BracketLayoutResult {
+  bracketTree: Map<number, TournamentMatchWithRobots[]>;
+  visibleRounds: number[];
+  matchPositions: Map<number, number>;
+  visibleHeight: number;
+  totalWidth: number;
+  connectorLines: React.ReactElement[];
+}
+
+/**
+ * Computes layout positions for the visible portion of a tournament bracket.
+ *
+ * When startRound > 1, positions are recalculated so the earliest visible
+ * round is laid out compactly (as if it were round 1), and subsequent rounds
+ * derive their Y from the midpoint of their two feeder matches. This keeps
+ * the filtered view tight and readable instead of preserving the full-bracket
+ * spacing which creates huge vertical gaps.
+ */
+export function useBracketLayout(
+  matches: TournamentMatchWithRobots[],
+  maxRounds: number,
+  startRound: number,
+  endRound: number,
+): BracketLayoutResult {
+  const bracketTree = buildBracketTree(matches, maxRounds);
+
+  const visibleRounds = Array.from(
+    { length: endRound - startRound + 1 },
+    (_, i) => startRound + i,
+  );
+
+  /**
+   * Compute Y-center positions for every visible match.
+   * The earliest visible round is spaced evenly (stride = CARD_HEIGHT + BASE_GAP).
+   * Later rounds center between their two feeder matches from the previous round.
+   */
+  const matchPositions = useMemo((): Map<number, number> => {
+    const positions = new Map<number, number>();
+    const stride = CARD_HEIGHT + BASE_GAP;
+
+    for (const round of visibleRounds) {
+      const roundMatches = bracketTree.get(round) ?? [];
+
+      if (round === startRound) {
+        // Base round: lay out compactly
+        for (let i = 0; i < roundMatches.length; i++) {
+          positions.set(roundMatches[i].id, i * stride + CARD_HEIGHT / 2);
+        }
+      } else {
+        const prevMatches = bracketTree.get(round - 1) ?? [];
+        for (let i = 0; i < roundMatches.length; i++) {
+          const f1 = prevMatches[i * 2];
+          const f2 = prevMatches[i * 2 + 1];
+          const y1 = f1 ? (positions.get(f1.id) ?? 0) : 0;
+          const y2 = f2 ? (positions.get(f2.id) ?? y1) : y1;
+          positions.set(roundMatches[i].id, (y1 + y2) / 2);
+        }
+      }
+    }
+    return positions;
+  }, [bracketTree, visibleRounds, startRound]);
+
+  const visibleHeight = useMemo((): number => {
+    const baseMatches = bracketTree.get(startRound) ?? [];
+    if (baseMatches.length === 0) return 200;
+    let maxY = 0;
+    for (const m of baseMatches) {
+      const y = matchPositions.get(m.id) ?? 0;
+      if (y > maxY) maxY = y;
+    }
+    return maxY + CARD_HEIGHT / 2 + 20;
+  }, [bracketTree, startRound, matchPositions]);
+
+  const numVisible = visibleRounds.length;
+  const totalWidth = numVisible * COLUMN_WIDTH + (numVisible - 1) * COLUMN_GAP + 24;
+
+  const connectorLines = useMemo((): React.ReactElement[] => {
+    const lines: React.ReactElement[] = [];
+
+    for (let vi = 0; vi < visibleRounds.length - 1; vi++) {
+      const round = visibleRounds[vi];
+      const nextRound = visibleRounds[vi + 1];
+      if (nextRound !== round + 1) continue;
+
+      const roundMatches = bracketTree.get(round) ?? [];
+      const nextMatches = bracketTree.get(nextRound) ?? [];
+
+      const colLeft = vi * (COLUMN_WIDTH + COLUMN_GAP) + 12;
+      const sourceX = colLeft + COLUMN_WIDTH;
+      const targetX = colLeft + COLUMN_WIDTH + COLUMN_GAP;
+      const midX = sourceX + COLUMN_GAP / 2;
+
+      for (let i = 0; i < nextMatches.length; i++) {
+        const nextMatch = nextMatches[i];
+        const f1 = roundMatches[i * 2];
+        const f2 = roundMatches[i * 2 + 1];
+        const nextY = (matchPositions.get(nextMatch.id) ?? 0) + LABEL_HEIGHT;
+
+        if (f1) {
+          const y1 = (matchPositions.get(f1.id) ?? 0) + LABEL_HEIGHT;
+          lines.push(
+            React.createElement('path', {
+              key: `c-${f1.id}-${nextMatch.id}`,
+              d: `M ${sourceX} ${y1} H ${midX} V ${nextY} H ${targetX}`,
+              fill: 'none', stroke: '#4b5563', strokeWidth: 1.5,
+            }),
+          );
+        }
+        if (f2) {
+          const y2 = (matchPositions.get(f2.id) ?? 0) + LABEL_HEIGHT;
+          lines.push(
+            React.createElement('path', {
+              key: `c-${f2.id}-${nextMatch.id}`,
+              d: `M ${sourceX} ${y2} H ${midX} V ${nextY} H ${targetX}`,
+              fill: 'none', stroke: '#4b5563', strokeWidth: 1.5,
+            }),
+          );
+        }
+      }
+    }
+    return lines;
+  }, [visibleRounds, bracketTree, matchPositions]);
+
+  return {
+    bracketTree,
+    visibleRounds,
+    matchPositions,
+    visibleHeight,
+    totalWidth,
+    connectorLines,
+  };
+}

--- a/prototype/frontend/src/hooks/useMediaQuery.ts
+++ b/prototype/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook that wraps window.matchMedia for responsive breakpoint detection.
+ * Returns true when the media query matches.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const handler = (event: MediaQueryListEvent): void => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+/**
+ * Convenience hook that returns true when viewport is 768px or narrower.
+ */
+export function useIsMobile(): boolean {
+  return useMediaQuery('(max-width: 768px)');
+}

--- a/prototype/frontend/src/hooks/useZoomPan.ts
+++ b/prototype/frontend/src/hooks/useZoomPan.ts
@@ -1,0 +1,90 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 2;
+const ZOOM_STEP = 0.05;
+
+export interface ZoomPanState {
+  scale: number;
+  translate: { x: number; y: number };
+  isPanning: boolean;
+  clampScale: (s: number) => number;
+  handleWheel: (e: React.WheelEvent) => void;
+  handleMouseDown: (e: React.MouseEvent) => void;
+  handleMouseMove: (e: React.MouseEvent) => void;
+  handleMouseUp: () => void;
+  handleTouchMove: (e: React.TouchEvent) => void;
+  handleTouchEnd: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  reset: () => void;
+}
+
+export function useZoomPan(resetDeps: unknown[] = []): ZoomPanState {
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const panStart = useRef({ x: 0, y: 0 });
+  const translateStart = useRef({ x: 0, y: 0 });
+  const lastTouchDistance = useRef<number | null>(null);
+
+  useEffect(() => {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+  }, resetDeps);
+
+  const clampScale = useCallback(
+    (s: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, s)),
+    [],
+  );
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    if (!e.ctrlKey) return;
+    e.preventDefault();
+    setScale((prev) => clampScale(prev + (e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP)));
+  }, [clampScale]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button === 1 || e.button === 0) {
+      e.preventDefault();
+      setIsPanning(true);
+      panStart.current = { x: e.clientX, y: e.clientY };
+      translateStart.current = { ...translate };
+    }
+  }, [translate]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isPanning) return;
+    setTranslate({
+      x: translateStart.current.x + (e.clientX - panStart.current.x),
+      y: translateStart.current.y + (e.clientY - panStart.current.y),
+    });
+  }, [isPanning]);
+
+  const handleMouseUp = useCallback(() => setIsPanning(false), []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length !== 2) return;
+    e.preventDefault();
+    const dx = e.touches[0].clientX - e.touches[1].clientX;
+    const dy = e.touches[0].clientY - e.touches[1].clientY;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    if (lastTouchDistance.current !== null) {
+      setScale((prev) => clampScale(prev + (distance - lastTouchDistance.current!) * 0.005));
+    }
+    lastTouchDistance.current = distance;
+  }, [clampScale]);
+
+  const handleTouchEnd = useCallback(() => { lastTouchDistance.current = null; }, []);
+
+  const zoomIn = useCallback(() => setScale((s) => clampScale(s + 0.1)), [clampScale]);
+  const zoomOut = useCallback(() => setScale((s) => clampScale(s - 0.1)), [clampScale]);
+  const reset = useCallback(() => { setScale(1); setTranslate({ x: 0, y: 0 }); }, []);
+
+  return {
+    scale, translate, isPanning, clampScale,
+    handleWheel, handleMouseDown, handleMouseMove, handleMouseUp,
+    handleTouchMove, handleTouchEnd,
+    zoomIn, zoomOut, reset,
+  };
+}

--- a/prototype/frontend/src/pages/TournamentDetailPage.tsx
+++ b/prototype/frontend/src/pages/TournamentDetailPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import Navigation from '../components/Navigation';
+import { getTournamentDetails, TournamentDetails, SeedEntry } from '../utils/tournamentApi';
+import { fetchMyRobots } from '../utils/robotApi';
+import BracketView from '../components/tournament/BracketView';
+
+/**
+ * Tournament Detail Page — displays full tournament info and bracket visualization.
+ * Route: /tournaments/:id
+ *
+ * Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.5, 8.6
+ */
+function TournamentDetailPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const { user, token, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const [tournament, setTournament] = useState<TournamentDetails | null>(null);
+  const [seedings, setSeedings] = useState<SeedEntry[]>([]);
+  const [userRobotIds, setUserRobotIds] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  const fetchTournament = useCallback(async () => {
+    if (!id) return;
+
+    const currentToken = token || localStorage.getItem('token');
+    if (!currentToken) {
+      logout();
+      navigate('/login');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      setNotFound(false);
+
+      const data = await getTournamentDetails(currentToken, parseInt(id, 10));
+      setTournament(data.tournament);
+      setSeedings(data.seedings);
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { status?: number } };
+      if (axiosErr.response?.status === 404) {
+        setNotFound(true);
+      } else if (axiosErr.response?.status === 401) {
+        logout();
+        navigate('/login');
+        return;
+      } else {
+        setError('Failed to load tournament details');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [id, token, logout, navigate]);
+
+  const fetchUserRobots = useCallback(async () => {
+    try {
+      const robots = await fetchMyRobots();
+      setUserRobotIds(new Set(robots.map((r) => r.id)));
+    } catch (err) {
+      console.error('Failed to fetch user robots:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTournament();
+    fetchUserRobots();
+  }, [fetchTournament, fetchUserRobots]);
+
+  if (!user) {
+    return <></>;
+  }
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white">
+        <Navigation />
+        <div className="w-full px-4 py-8">
+          <div className="animate-pulse space-y-4">
+            <div className="h-4 w-32 bg-gray-700 rounded" />
+            <div className="h-8 w-64 bg-gray-700 rounded" />
+            <div className="flex gap-3 flex-wrap">
+              <div className="h-6 w-20 bg-gray-700 rounded-full" />
+              <div className="h-6 w-28 bg-gray-700 rounded" />
+              <div className="h-6 w-28 bg-gray-700 rounded" />
+              <div className="h-6 w-36 bg-gray-700 rounded" />
+            </div>
+            <div className="h-96 bg-gray-800 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 404 — tournament not found
+  if (notFound) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white">
+        <Navigation />
+        <div className="container mx-auto px-4 py-8">
+          <div className="bg-gray-800 border border-gray-700 p-8 rounded-lg text-center">
+            <p className="text-xl text-gray-300 mb-4">Tournament not found</p>
+            <Link
+              to="/tournaments"
+              className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded text-white"
+            >
+              Back to Tournaments
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state with retry
+  if (error || !tournament) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white">
+        <Navigation />
+        <div className="container mx-auto px-4 py-8">
+          <div className="bg-red-900/30 border border-red-600 p-6 rounded-lg">
+            <p className="text-red-400 mb-4">{error || 'Something went wrong'}</p>
+            <div className="flex gap-3">
+              <button
+                onClick={fetchTournament}
+                className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-white"
+              >
+                Retry
+              </button>
+              <Link
+                to="/tournaments"
+                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-white"
+              >
+                Back to Tournaments
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <Navigation />
+      <div className="w-full px-4 py-6">
+        {/* Back link */}
+        <Link
+          to="/tournaments"
+          className="inline-flex items-center text-gray-400 hover:text-white mb-4 text-sm"
+        >
+          ← Back to Tournaments
+        </Link>
+
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 flex-wrap mb-2">
+            <h1 className="text-2xl font-bold">{tournament.name}</h1>
+            <StatusBadge status={tournament.status} />
+          </div>
+
+          <div className="flex items-center gap-4 text-sm text-gray-400 flex-wrap">
+            <span>
+              Round {tournament.currentRound} / {tournament.maxRounds}
+            </span>
+            <span>•</span>
+            <span>{tournament.totalParticipants} participants</span>
+            <span>•</span>
+            <span>Created {new Date(tournament.createdAt).toLocaleDateString()}</span>
+          </div>
+        </div>
+
+        {/* Champion banner */}
+        {tournament.status === 'completed' && tournament.winner && (
+          <div className="bg-yellow-900/30 border border-yellow-600 rounded-lg p-4 mb-6 flex items-center gap-3">
+            <span className="text-2xl">🏆</span>
+            <div>
+              <p className="text-yellow-400 font-semibold text-lg">
+                Champion: {tournament.winner.name}
+              </p>
+              <p className="text-yellow-600 text-sm">Tournament Winner</p>
+            </div>
+          </div>
+        )}
+
+        {/* Bracket visualization */}
+        <BracketView
+          matches={tournament.matches}
+          seedings={seedings}
+          maxRounds={tournament.maxRounds}
+          currentRound={tournament.currentRound}
+          status={tournament.status}
+          userRobotIds={userRobotIds}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Status badge for tournament status */
+function StatusBadge({ status }: { status: string }): JSX.Element {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-600 text-gray-200',
+    active: 'bg-green-700 text-green-200',
+    completed: 'bg-blue-700 text-blue-200',
+  };
+
+  const labels: Record<string, string> = {
+    pending: 'Pending',
+    active: 'Active',
+    completed: 'Completed',
+  };
+
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${styles[status] || 'bg-gray-600 text-gray-200'}`}>
+      {labels[status] || status}
+    </span>
+  );
+}
+
+export default TournamentDetailPage;

--- a/prototype/frontend/src/pages/TournamentsPage.tsx
+++ b/prototype/frontend/src/pages/TournamentsPage.tsx
@@ -2,56 +2,21 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import Navigation from '../components/Navigation';
-import { listTournaments, getTournamentDetails, Tournament, TournamentDetails } from '../utils/tournamentApi';
-import { fetchMyRobots } from '../utils/robotApi';
+import { listTournaments, Tournament } from '../utils/tournamentApi';
+import { getRoundLabel } from '../utils/bracketUtils';
 
 function TournamentsPage() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const [tournaments, setTournaments] = useState<Tournament[]>([]);
-  const [selectedTournament, setSelectedTournament] = useState<TournamentDetails | null>(null);
-  const [userRobots, setUserRobots] = useState<Set<number>>(new Set());
   const [loading, setLoading] = useState(true);
-  const [detailsLoading, setDetailsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all');
-  const [showOnlyUserRobots, setShowOnlyUserRobots] = useState(false);
-  const [matchesPage, setMatchesPage] = useState(1);
-  const [matchesPerPage, setMatchesPerPage] = useState(50);  useEffect(() => {
+
+  useEffect(() => {
     fetchTournaments();
-    fetchUserRobots();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const fetchUserRobots = async () => {
-    try {
-      const robots = await fetchMyRobots();
-      const robotIds = new Set<number>(robots.map((r) => r.id));
-      setUserRobots(robotIds);
-    } catch (err) {
-      console.error('Failed to fetch user robots:', err);
-    }
-  };
-
-  const fetchTournamentDetails = async (tournamentId: number) => {
-    try {
-      setDetailsLoading(true);
-      const token = localStorage.getItem('token');
-      if (!token) {
-        logout();
-        navigate('/login');
-        return;
-      }
-
-      const data = await getTournamentDetails(token, tournamentId);
-      setSelectedTournament(data.tournament);
-    } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-      console.error('Failed to fetch tournament details:', err);
-      setError('Failed to load tournament details');
-    } finally {
-      setDetailsLoading(false);
-    }
-  };
 
   const fetchTournaments = async () => {
     try {
@@ -84,12 +49,8 @@ function TournamentsPage() {
     return tournaments.filter(t => t.status === filter);
   };
 
-  const getRoundName = (currentRound: number, maxRounds: number) => {
-    const remainingRounds = maxRounds - currentRound + 1;
-    if (remainingRounds === 1) return 'Finals';
-    if (remainingRounds === 2) return 'Semi-finals';
-    if (remainingRounds === 3) return 'Quarter-finals';
-    return `Round ${currentRound}/${maxRounds}`;
+  const getRoundName = (currentRound: number, maxRounds: number): string => {
+    return getRoundLabel(currentRound, maxRounds);
   };
 
   const getStatusBadge = (status: string) => {
@@ -290,7 +251,7 @@ function TournamentsPage() {
                 {/* View Details Button */}
                 <div className="mt-4">
                   <button
-                    onClick={() => fetchTournamentDetails(tournament.id)}
+                    onClick={() => navigate(`/tournaments/${tournament.id}`)}
                     className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded transition-colors font-semibold"
                   >
                     View Tournament Details
@@ -301,285 +262,6 @@ function TournamentsPage() {
           </div>
         )}
 
-        {/* Tournament Details Modal */}
-        {selectedTournament && (
-          <div className="fixed inset-0 bg-black/80 flex items-center justify-center p-4 z-50 overflow-y-auto">
-            <div className="bg-gray-800 rounded-lg max-w-6xl w-full max-h-[90vh] overflow-y-auto border-2 border-yellow-500/50">
-              {/* Header */}
-              <div className="sticky top-0 bg-gray-800 border-b border-gray-700 p-6 flex justify-between items-center">
-                <div>
-                  <h2 className="text-3xl font-bold text-yellow-400 mb-1">{selectedTournament.name}</h2>
-                  <div className="flex items-center gap-3">
-                    {getStatusBadge(selectedTournament.status)}
-                    <span className="text-gray-400">
-                      Round {selectedTournament.currentRound} of {selectedTournament.maxRounds}
-                    </span>
-                  </div>
-                </div>
-                <button
-                  onClick={() => setSelectedTournament(null)}
-                  className="text-gray-400 hover:text-white text-3xl leading-none"
-                >
-                  ×
-                </button>
-              </div>
-
-              {detailsLoading ? (
-                <div className="p-12 text-center">
-                  <p className="text-gray-400">Loading tournament details...</p>
-                </div>
-              ) : (
-                <div className="p-6">
-                  {/* Tournament Info */}
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-                    <div className="bg-gray-900 p-4 rounded-lg">
-                      <div className="text-sm text-gray-400">Total Participants</div>
-                      <div className="text-2xl font-bold">{selectedTournament.totalParticipants}</div>
-                    </div>
-                    <div className="bg-gray-900 p-4 rounded-lg">
-                      <div className="text-sm text-gray-400">Robots Remaining</div>
-                      <div className="text-2xl font-bold text-green-400">
-                        {(() => {
-                          const matches = selectedTournament.currentRoundMatches || [];
-                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          const regularMatches = matches.filter((m: any) => !m.isByeMatch).length;
-                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          const byeMatches = matches.filter((m: any) => m.isByeMatch).length;
-                          return (regularMatches * 2) + byeMatches;
-                        })()}
-                      </div>
-                    </div>
-                    <div className="bg-gray-900 p-4 rounded-lg">
-                      <div className="text-sm text-gray-400">Total Rounds</div>
-                      <div className="text-2xl font-bold">{selectedTournament.maxRounds}</div>
-                    </div>
-                    <div className="bg-gray-900 p-4 rounded-lg">
-                      <div className="text-sm text-gray-400">Your Robots</div>
-                      <div className="text-2xl font-bold text-blue-400">
-                        {(() => {
-                          const userRobotIds = new Set<number>();
-                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          selectedTournament.currentRoundMatches?.forEach((m: any) => {
-                            if (m.robot1Id && userRobots.has(m.robot1Id)) {
-                              userRobotIds.add(m.robot1Id);
-                            }
-                            if (m.robot2Id && userRobots.has(m.robot2Id)) {
-                              userRobotIds.add(m.robot2Id);
-                            }
-                          });
-                          return userRobotIds.size;
-                        })()}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* User's Robots in Tournament */}
-                  {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                  {selectedTournament.currentRoundMatches && selectedTournament.currentRoundMatches.some((m: any) => 
-                    (m.robot1Id && userRobots.has(m.robot1Id)) || 
-                    (m.robot2Id && userRobots.has(m.robot2Id))
-                  ) && (
-                    <div className="bg-blue-900/20 border border-blue-500/50 p-4 rounded-lg mb-6">
-                      <h3 className="text-xl font-bold text-blue-400 mb-3 flex items-center gap-2">
-                        <span>🤖</span>
-                        Your Robots Still In Tournament
-                      </h3>
-                      <div className="space-y-2">
-                        {selectedTournament.currentRoundMatches
-                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          .filter((m: any) => 
-                            (m.robot1Id && userRobots.has(m.robot1Id)) || 
-                            (m.robot2Id && userRobots.has(m.robot2Id))
-                          )
-                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          .map((match: any) => {
-                            const userRobot = userRobots.has(match.robot1Id) ? match.robot1 : match.robot2;
-                            const opponent = userRobots.has(match.robot1Id) ? match.robot2 : match.robot1;
-                            
-                            return (
-                              <div key={match.id} className="bg-gray-900 p-3 rounded flex justify-between items-center">
-                                <div>
-                                  <span className="font-bold text-blue-400">{userRobot?.name || 'Your Robot'}</span>
-                                  {match.status === 'completed' ? (
-                                    <span className="ml-2 text-sm">
-                                      {match.winnerId === userRobot?.id ? (
-                                        <span className="text-green-400">✓ Advanced</span>
-                                      ) : (
-                                        <span className="text-red-400">✗ Eliminated</span>
-                                      )}
-                                    </span>
-                                  ) : match.isByeMatch ? (
-                                    <span className="ml-2 text-sm text-yellow-400">Bye (Auto-advance)</span>
-                                  ) : (
-                                    <span className="ml-2 text-sm text-gray-400">
-                                      vs {opponent?.name || 'TBD'}
-                                    </span>
-                                  )}
-                                </div>
-                                <div className="text-sm text-gray-400">
-                                  {match.isByeMatch ? 'No Match' : 
-                                    match.status === 'completed' ? 'Completed' : 'Pending'}
-                                </div>
-                              </div>
-                            );
-                          })}
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Current Round Matches */}
-                  <div>
-                    <div className="flex justify-between items-center mb-4">
-                      <h3 className="text-xl font-bold">
-                        {getRoundName(selectedTournament.currentRound, selectedTournament.maxRounds)} Matches
-                      </h3>
-                      <div className="flex items-center gap-4">
-                        <label className="flex items-center gap-2 text-sm">
-                          <input
-                            type="checkbox"
-                            checked={showOnlyUserRobots}
-                            onChange={(e) => {
-                              setShowOnlyUserRobots(e.target.checked);
-                              setMatchesPage(1); // Reset to first page
-                            }}
-                            className="rounded"
-                          />
-                          <span className="text-gray-300">Show only my robots</span>
-                        </label>
-                        <select
-                          value={matchesPerPage}
-                          onChange={(e) => {
-                            setMatchesPerPage(Number(e.target.value));
-                            setMatchesPage(1); // Reset to first page
-                          }}
-                          className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm"
-                        >
-                          <option value={25}>25 per page</option>
-                          <option value={50}>50 per page</option>
-                          <option value={100}>100 per page</option>
-                          <option value={500}>500 per page</option>
-                        </select>
-                      </div>
-                    </div>
-                    
-                    {selectedTournament.currentRoundMatches && selectedTournament.currentRoundMatches.length > 0 ? (
-                      <>
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
-                          {(() => {
-                            // Filter matches if "show only my robots" is enabled
-                            const filteredMatches = showOnlyUserRobots
-                              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                              ? selectedTournament.currentRoundMatches.filter((m: any) =>
-                                  (m.robot1Id && userRobots.has(m.robot1Id)) ||
-                                  (m.robot2Id && userRobots.has(m.robot2Id))
-                                )
-                              : selectedTournament.currentRoundMatches;
-
-                            // Pagination
-                            const totalMatches = filteredMatches.length;
-                            const totalPages = Math.ceil(totalMatches / matchesPerPage);
-                            const startIndex = (matchesPage - 1) * matchesPerPage;
-                            const endIndex = startIndex + matchesPerPage;
-                            const paginatedMatches = filteredMatches.slice(startIndex, endIndex);
-
-                            return (
-                              <>
-                                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                                {paginatedMatches.map((match: any) => (
-                                  <div
-                                    key={match.id}
-                                    className={`p-3 rounded border ${
-                                      match.status === 'completed'
-                                        ? 'bg-gray-900/50 border-gray-700'
-                                        : 'bg-gray-900 border-yellow-500/30'
-                                    }`}
-                                  >
-                                    {match.isByeMatch ? (
-                                      <div className="text-center py-2">
-                                        <div className="font-bold text-yellow-400">
-                                          {match.robot1?.name || 'Robot'}
-                                        </div>
-                                        <div className="text-xs text-gray-400">
-                                          ELO: {match.robot1?.elo || 'N/A'}
-                                        </div>
-                                        {match.robot1?.user && (
-                                          <div className="text-xs text-gray-500">
-                                            {match.robot1.user.stableName || match.robot1.user.username}
-                                          </div>
-                                        )}
-                                        <div className="text-xs text-yellow-300 mt-1">🎖️ Bye - Auto-advances</div>
-                                      </div>
-                                    ) : (
-                                      <>
-                                        <div className="flex justify-between items-start gap-2">
-                                          <div className={`flex-1 ${match.winnerId === match.robot1Id ? 'font-bold text-green-400' : ''}`}>
-                                            <div>{match.robot1?.name || 'TBD'}</div>
-                                            <div className="text-xs text-gray-400">
-                                              ELO: {match.robot1?.elo || 'N/A'}
-                                            </div>
-                                            {match.robot1?.user && (
-                                              <div className="text-xs text-gray-500">
-                                                {match.robot1.user.stableName || match.robot1.user.username}
-                                              </div>
-                                            )}
-                                          </div>
-                                          <div className="px-2 text-gray-500 text-xs pt-2">VS</div>
-                                          <div className={`flex-1 text-right ${match.winnerId === match.robot2Id ? 'font-bold text-green-400' : ''}`}>
-                                            <div>{match.robot2?.name || 'TBD'}</div>
-                                            <div className="text-xs text-gray-400">
-                                              ELO: {match.robot2?.elo || 'N/A'}
-                                            </div>
-                                            {match.robot2?.user && (
-                                              <div className="text-xs text-gray-500">
-                                                {match.robot2.user.stableName || match.robot2.user.username}
-                                              </div>
-                                            )}
-                                          </div>
-                                        </div>
-                                        <div className="text-center text-xs text-gray-500 mt-2">
-                                          {match.status === 'completed' ? '✓ Completed' : 'Pending'}
-                                        </div>
-                                      </>
-                                    )}
-                                  </div>
-                                ))}
-
-                                {/* Pagination Controls */}
-                                {totalPages > 1 && (
-                                  <div className="col-span-full flex justify-center items-center gap-4 mt-4">
-                                    <button
-                                      onClick={() => setMatchesPage(Math.max(1, matchesPage - 1))}
-                                      disabled={matchesPage === 1}
-                                      className="px-4 py-2 bg-gray-800 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700"
-                                    >
-                                      Previous
-                                    </button>
-                                    <span className="text-gray-400">
-                                      Page {matchesPage} of {totalPages} ({totalMatches} matches)
-                                    </span>
-                                    <button
-                                      onClick={() => setMatchesPage(Math.min(totalPages, matchesPage + 1))}
-                                      disabled={matchesPage === totalPages}
-                                      className="px-4 py-2 bg-gray-800 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700"
-                                    >
-                                      Next
-                                    </button>
-                                  </div>
-                                )}
-                              </>
-                            );
-                          })()}
-                        </div>
-                      </>
-                    ) : (
-                      <p className="text-gray-400 text-center py-8">No matches in current round</p>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/prototype/frontend/src/utils/__tests__/bracketUtils.test.ts
+++ b/prototype/frontend/src/utils/__tests__/bracketUtils.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRoundLabel,
+  buildBracketTree,
+  formatSeedDisplay,
+  getUserFuturePath,
+  TournamentMatchWithRobots,
+} from '../bracketUtils';
+
+/** Helper to create a minimal match object for testing */
+function makeMatch(overrides: Partial<TournamentMatchWithRobots> & { id: number; round: number; matchNumber: number }): TournamentMatchWithRobots {
+  return {
+    tournamentId: 1,
+    robot1Id: null,
+    robot2Id: null,
+    winnerId: null,
+    battleId: null,
+    status: 'pending',
+    isByeMatch: false,
+    completedAt: null,
+    robot1: null,
+    robot2: null,
+    winner: null,
+    ...overrides,
+  };
+}
+
+describe('getRoundLabel', () => {
+  it('should return "Finals" when round equals maxRounds', () => {
+    expect(getRoundLabel(4, 4)).toBe('Finals');
+    expect(getRoundLabel(1, 1)).toBe('Finals');
+    expect(getRoundLabel(7, 7)).toBe('Finals');
+  });
+
+  it('should return "Semi-finals" when round is maxRounds - 1', () => {
+    expect(getRoundLabel(3, 4)).toBe('Semi-finals');
+    expect(getRoundLabel(6, 7)).toBe('Semi-finals');
+  });
+
+  it('should return "Quarter-finals" when round is maxRounds - 2', () => {
+    expect(getRoundLabel(2, 4)).toBe('Quarter-finals');
+    expect(getRoundLabel(5, 7)).toBe('Quarter-finals');
+  });
+
+  it('should return "Round N" for earlier rounds', () => {
+    expect(getRoundLabel(1, 4)).toBe('Round 1');
+    expect(getRoundLabel(1, 7)).toBe('Round 1');
+    expect(getRoundLabel(3, 7)).toBe('Round 3');
+    expect(getRoundLabel(4, 7)).toBe('Round 4');
+  });
+
+  it('should handle 2-round tournament correctly', () => {
+    expect(getRoundLabel(1, 2)).toBe('Semi-finals');
+    expect(getRoundLabel(2, 2)).toBe('Finals');
+  });
+
+  it('should handle 3-round tournament correctly', () => {
+    expect(getRoundLabel(1, 3)).toBe('Quarter-finals');
+    expect(getRoundLabel(2, 3)).toBe('Semi-finals');
+    expect(getRoundLabel(3, 3)).toBe('Finals');
+  });
+});
+
+describe('buildBracketTree', () => {
+  it('should organize matches into a Map keyed by round', () => {
+    const matches: TournamentMatchWithRobots[] = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1 }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2 }),
+      makeMatch({ id: 3, round: 2, matchNumber: 1 }),
+    ];
+
+    const tree = buildBracketTree(matches, 2);
+
+    expect(tree.size).toBe(2);
+    expect(tree.get(1)!.length).toBe(2);
+    expect(tree.get(2)!.length).toBe(1);
+  });
+
+  it('should sort matches within each round by matchNumber', () => {
+    const matches: TournamentMatchWithRobots[] = [
+      makeMatch({ id: 3, round: 1, matchNumber: 3 }),
+      makeMatch({ id: 1, round: 1, matchNumber: 1 }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2 }),
+    ];
+
+    const tree = buildBracketTree(matches, 1);
+    const round1 = tree.get(1)!;
+
+    expect(round1[0].matchNumber).toBe(1);
+    expect(round1[1].matchNumber).toBe(2);
+    expect(round1[2].matchNumber).toBe(3);
+  });
+
+  it('should initialize empty arrays for rounds with no matches', () => {
+    const matches: TournamentMatchWithRobots[] = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1 }),
+    ];
+
+    const tree = buildBracketTree(matches, 3);
+
+    expect(tree.get(1)!.length).toBe(1);
+    expect(tree.get(2)!.length).toBe(0);
+    expect(tree.get(3)!.length).toBe(0);
+  });
+
+  it('should handle empty matches array', () => {
+    const tree = buildBracketTree([], 3);
+
+    expect(tree.size).toBe(3);
+    expect(tree.get(1)!.length).toBe(0);
+    expect(tree.get(2)!.length).toBe(0);
+    expect(tree.get(3)!.length).toBe(0);
+  });
+});
+
+describe('formatSeedDisplay', () => {
+  it('should prefix seed number for seeds 1-32', () => {
+    expect(formatSeedDisplay(1, 'AlphaBot')).toBe('#1 AlphaBot');
+    expect(formatSeedDisplay(16, 'BetaBot')).toBe('#16 BetaBot');
+    expect(formatSeedDisplay(32, 'GammaBot')).toBe('#32 GammaBot');
+  });
+
+  it('should return just the name for seeds > 32', () => {
+    expect(formatSeedDisplay(33, 'DeltaBot')).toBe('DeltaBot');
+    expect(formatSeedDisplay(64, 'EpsilonBot')).toBe('EpsilonBot');
+    expect(formatSeedDisplay(128, 'ZetaBot')).toBe('ZetaBot');
+  });
+});
+
+describe('getUserFuturePath', () => {
+  it('should return empty set when no user robot IDs provided', () => {
+    const matches = [makeMatch({ id: 1, round: 1, matchNumber: 1 })];
+    const result = getUserFuturePath(matches, new Set(), 2);
+    expect(result.size).toBe(0);
+  });
+
+  it('should return empty set when matches array is empty', () => {
+    const result = getUserFuturePath([], new Set([1]), 2);
+    expect(result.size).toBe(0);
+  });
+
+  it('should return empty set when user robot is not in any match', () => {
+    const matches = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1, robot1Id: 10, robot2Id: 20 }),
+    ];
+    const result = getUserFuturePath(matches, new Set([99]), 2);
+    expect(result.size).toBe(0);
+  });
+
+  it('should compute future path for a robot in round 1 of a 3-round bracket', () => {
+    // 4-match round 1, 2-match round 2, 1-match round 3
+    const matches = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1, robot1Id: 10, robot2Id: 20, status: 'pending' }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2, robot1Id: 30, robot2Id: 40, status: 'pending' }),
+      makeMatch({ id: 3, round: 1, matchNumber: 3, robot1Id: 50, robot2Id: 60, status: 'pending' }),
+      makeMatch({ id: 4, round: 1, matchNumber: 4, robot1Id: 70, robot2Id: 80, status: 'pending' }),
+      makeMatch({ id: 5, round: 2, matchNumber: 1 }), // winner of match 1 vs winner of match 2
+      makeMatch({ id: 6, round: 2, matchNumber: 2 }), // winner of match 3 vs winner of match 4
+      makeMatch({ id: 7, round: 3, matchNumber: 1 }), // finals
+    ];
+
+    // Robot 10 is in match 1 (round 1, matchNumber 1)
+    // Next: round 2, matchNumber ceil(1/2)=1 → match id 5
+    // Then: round 3, matchNumber ceil(1/2)=1 → match id 7
+    const result = getUserFuturePath(matches, new Set([10]), 3);
+    expect(result).toEqual(new Set([5, 7]));
+  });
+
+  it('should not include future matches for an eliminated robot', () => {
+    const matches = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1, robot1Id: 10, robot2Id: 20, winnerId: 20, status: 'completed' }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2, robot1Id: 30, robot2Id: 40, status: 'pending' }),
+      makeMatch({ id: 3, round: 2, matchNumber: 1 }),
+    ];
+
+    // Robot 10 lost in match 1
+    const result = getUserFuturePath(matches, new Set([10]), 2);
+    expect(result.size).toBe(0);
+  });
+
+  it('should trace from the current match when robot has already advanced', () => {
+    const matches = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1, robot1Id: 10, robot2Id: 20, winnerId: 10, status: 'completed' }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2, robot1Id: 30, robot2Id: 40, winnerId: 30, status: 'completed' }),
+      makeMatch({ id: 3, round: 2, matchNumber: 1, robot1Id: 10, robot2Id: 30, status: 'pending' }),
+      makeMatch({ id: 4, round: 1, matchNumber: 3, robot1Id: 50, robot2Id: 60, status: 'pending' }),
+      makeMatch({ id: 5, round: 1, matchNumber: 4, robot1Id: 70, robot2Id: 80, status: 'pending' }),
+      makeMatch({ id: 6, round: 2, matchNumber: 2 }),
+      makeMatch({ id: 7, round: 3, matchNumber: 1 }),
+    ];
+
+    // Robot 10 won round 1 and is now in round 2 match 1
+    // From round 2 match 1: next is round 3 matchNumber ceil(1/2)=1 → match id 7
+    // From round 1 match 1 (completed win): round 2 match 1 has robot 10 already assigned, so not "future"
+    const result = getUserFuturePath(matches, new Set([10]), 3);
+    expect(result).toEqual(new Set([7]));
+  });
+
+  it('should handle multiple user robots', () => {
+    const matches = [
+      makeMatch({ id: 1, round: 1, matchNumber: 1, robot1Id: 10, robot2Id: 20, status: 'pending' }),
+      makeMatch({ id: 2, round: 1, matchNumber: 2, robot1Id: 30, robot2Id: 40, status: 'pending' }),
+      makeMatch({ id: 3, round: 2, matchNumber: 1 }),
+    ];
+
+    // Both robot 10 and robot 30 belong to the user
+    const result = getUserFuturePath(matches, new Set([10, 30]), 2);
+    // Both trace to match 3 (round 2, matchNumber 1)
+    expect(result).toEqual(new Set([3]));
+  });
+});

--- a/prototype/frontend/src/utils/bracketUtils.ts
+++ b/prototype/frontend/src/utils/bracketUtils.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared bracket utility functions for tournament visualization.
+ * Extracted from TournamentsPage.tsx and extended per the bracket seeding design.
+ */
+
+/** Match data with robot relations, as returned by the tournament detail API */
+export interface TournamentMatchWithRobots {
+  id: number;
+  tournamentId: number;
+  round: number;
+  matchNumber: number;
+  robot1Id: number | null;
+  robot2Id: number | null;
+  winnerId: number | null;
+  battleId: number | null;
+  status: string;
+  isByeMatch: boolean;
+  completedAt: string | null;
+  robot1: { id: number; name: string; elo: number } | null;
+  robot2: { id: number; name: string; elo: number } | null;
+  winner: { id: number; name: string } | null;
+}
+
+/**
+ * Returns a human-readable label for a tournament round.
+ *
+ * - Finals when round === maxRounds
+ * - Semi-finals when round === maxRounds - 1
+ * - Quarter-finals when round === maxRounds - 2
+ * - "Round N" otherwise
+ *
+ * Validates: Requirement 7.1
+ */
+export function getRoundLabel(round: number, maxRounds: number): string {
+  if (round === maxRounds) return 'Finals';
+  if (round === maxRounds - 1) return 'Semi-finals';
+  if (round === maxRounds - 2) return 'Quarter-finals';
+  return `Round ${round}`;
+}
+
+/**
+ * Organizes a flat match array into a Map keyed by round number.
+ * Each round's matches are sorted by matchNumber ascending.
+ *
+ * Validates: Requirement 3.1
+ */
+export function buildBracketTree(
+  matches: TournamentMatchWithRobots[],
+  maxRounds: number
+): Map<number, TournamentMatchWithRobots[]> {
+  const tree = new Map<number, TournamentMatchWithRobots[]>();
+
+  // Initialize empty arrays for every round so the map is complete
+  for (let r = 1; r <= maxRounds; r++) {
+    tree.set(r, []);
+  }
+
+  for (const match of matches) {
+    const roundMatches = tree.get(match.round);
+    if (roundMatches) {
+      roundMatches.push(match);
+    }
+  }
+
+  // Sort each round's matches by matchNumber ascending
+  for (const [, roundMatches] of tree) {
+    roundMatches.sort((a, b) => a.matchNumber - b.matchNumber);
+  }
+
+  return tree;
+}
+
+/**
+ * Formats a seed number + robot name for display.
+ * Seeds 1–32 get a "#N" prefix; seeds > 32 show just the name.
+ *
+ * Validates: Requirements 4.1, 4.2
+ */
+export function formatSeedDisplay(seed: number, robotName: string): string {
+  if (seed <= 32) return `#${seed} ${robotName}`;
+  return robotName;
+}
+
+/**
+ * Computes the set of future match IDs the user's robot would play
+ * if it keeps winning from its current position.
+ *
+ * Algorithm:
+ * 1. Find the user's latest (highest-round) match where they are assigned.
+ * 2. From that match, walk up the bracket: the next match in round N+1
+ *    has matchNumber = Math.ceil(currentMatchNumber / 2).
+ * 3. Collect the IDs of those future matches.
+ *
+ * Validates: Requirement 6.3
+ */
+export function getUserFuturePath(
+  matches: TournamentMatchWithRobots[],
+  userRobotIds: Set<number>,
+  maxRounds: number
+): Set<number> {
+  const futureMatchIds = new Set<number>();
+
+  if (userRobotIds.size === 0 || matches.length === 0) {
+    return futureMatchIds;
+  }
+
+  // Build a lookup: (round, matchNumber) → match
+  const matchLookup = new Map<string, TournamentMatchWithRobots>();
+  for (const match of matches) {
+    matchLookup.set(`${match.round}-${match.matchNumber}`, match);
+  }
+
+  // Find all matches the user's robots are in
+  const userMatches = matches.filter(
+    (m) =>
+      (m.robot1Id !== null && userRobotIds.has(m.robot1Id)) ||
+      (m.robot2Id !== null && userRobotIds.has(m.robot2Id))
+  );
+
+  if (userMatches.length === 0) {
+    return futureMatchIds;
+  }
+
+  // For each user robot, find their latest match and trace the future path
+  for (const userMatch of userMatches) {
+    // Only trace forward from matches that haven't been lost
+    const userRobotId = userRobotIds.has(userMatch.robot1Id ?? -1)
+      ? userMatch.robot1Id
+      : userMatch.robot2Id;
+
+    // If the match is completed and the user's robot lost, skip
+    if (
+      userMatch.status === 'completed' &&
+      userMatch.winnerId !== null &&
+      userMatch.winnerId !== userRobotId
+    ) {
+      continue;
+    }
+
+    // Walk up the bracket from this match
+    let currentRound = userMatch.round;
+    let currentMatchNumber = userMatch.matchNumber;
+
+    while (currentRound < maxRounds) {
+      const nextRound = currentRound + 1;
+      const nextMatchNumber = Math.ceil(currentMatchNumber / 2);
+      const nextMatch = matchLookup.get(`${nextRound}-${nextMatchNumber}`);
+
+      if (nextMatch) {
+        // Only add if the user's robot isn't already assigned to this match
+        // (if they are, it's a current match, not a future one)
+        const alreadyAssigned =
+          (nextMatch.robot1Id !== null && userRobotIds.has(nextMatch.robot1Id)) ||
+          (nextMatch.robot2Id !== null && userRobotIds.has(nextMatch.robot2Id));
+
+        if (!alreadyAssigned) {
+          futureMatchIds.add(nextMatch.id);
+        }
+      }
+
+      currentRound = nextRound;
+      currentMatchNumber = nextMatchNumber;
+    }
+  }
+
+  return futureMatchIds;
+}

--- a/prototype/frontend/src/utils/tournamentApi.ts
+++ b/prototype/frontend/src/utils/tournamentApi.ts
@@ -1,6 +1,16 @@
 import apiClient from './apiClient';
+import type { TournamentMatchWithRobots } from './bracketUtils';
 
 // Types
+
+export interface SeedEntry {
+  seed: number;
+  robotId: number;
+  robotName: string;
+  elo: number;
+  eliminated: boolean;
+}
+
 export interface Tournament {
   id: number;
   name: string;
@@ -58,9 +68,10 @@ export interface TournamentMatch {
 }
 
 export interface TournamentDetails extends Tournament {
-  matches: TournamentMatch[];
+  matches: TournamentMatchWithRobots[];
   currentRoundMatches: TournamentMatch[];
   participantCount: number;
+  seedings: SeedEntry[];
 }
 
 export interface CreateTournamentResponse {
@@ -114,16 +125,18 @@ export const listTournaments = async (_token: string): Promise<{ tournaments: To
 export const getTournamentDetails = async (
   _token: string,
   tournamentId: number
-): Promise<{ tournament: TournamentDetails }> => {
+): Promise<{ tournament: TournamentDetails; seedings: SeedEntry[] }> => {
   const response = await apiClient.get(`/api/tournaments/${tournamentId}`);
   
-  // Backend returns tournament directly
-  const { tournament } = response.data;
+  // Backend returns tournament and seedings
+  const { tournament, seedings = [] } = response.data;
   return {
     tournament: {
       ...tournament,
       currentRoundMatches: tournament.matches?.filter((m: TournamentMatch) => m.round === tournament.currentRound) || [],
-    }
+      seedings,
+    },
+    seedings,
   };
 };
 


### PR DESCRIPTION
- Backend: computeSeedings(), seedRobotsByELO(), generateStandardSeedOrder()
- API: GET /tournaments/:id returns seedings and bracket data
- Frontend: TournamentDetailPage with interactive bracket viewer
- Components: DesktopBracket, MobileBracket, MatchCard, SeedingList, BracketView
- Hooks: useBracketLayout (compact round filtering), useZoomPan, useMediaQuery
- Features: round range filter, user robot highlighting, scroll-to-bot, zoom/pan
- Tests: property-based (fast-check) and unit tests for backend and frontend