### PR TITLE
fix: league rebalancing, cycle number off-by-one, per-robot streaming…

### DIFF
--- a/prototype/backend/src/routes/admin.ts
+++ b/prototype/backend/src/routes/admin.ts
@@ -409,6 +409,13 @@ router.post('/cycles/bulk', authenticateToken, requireAdmin, async (req: Request
       logger.info(`\n[Admin] === Cycle ${currentCycleNumber} (${i}/${cycleCount}) ===`);
 
       try {
+        // Advance cycle number in DB so getCurrentCycleNumber() returns the
+        // correct value when called by battle orchestrators during this cycle.
+        await prisma.cycleMetadata.update({
+          where: { id: 1 },
+          data: { totalCycles: currentCycleNumber },
+        });
+
         // Log cycle start
         await eventLogger.logCycleStart(currentCycleNumber, 'manual');
 
@@ -649,15 +656,14 @@ router.post('/cycles/bulk', authenticateToken, requireAdmin, async (req: Request
           logger.info(`[Admin] Step 9.5: Skipping Tag Team Matchmaking (even cycle ${currentCycleNumber})`);
         }
 
-        // Step 10: Increment Cycle Counters
-        logger.info(`[Admin] Step 10: Increment Cycle Counters`);
+        // Step 10: Finalize Cycle Counters
+        logger.info(`[Admin] Step 10: Finalize Cycle Counters`);
         const step10Start = Date.now();
         
-        // Update cycle metadata with current cycle number
+        // Update lastCycleAt timestamp (totalCycles already set at cycle start)
         await prisma.cycleMetadata.update({
           where: { id: 1 },
           data: {
-            totalCycles: currentCycleNumber,
             lastCycleAt: new Date(),
           },
         });

--- a/prototype/backend/src/services/battleOrchestrator.ts
+++ b/prototype/backend/src/services/battleOrchestrator.ts
@@ -35,14 +35,15 @@ const BYE_ROBOT_NAME = 'Bye Robot';
 
 /**
  * Get the current cycle number from metadata
- * Returns the CURRENT cycle (totalCycles + 1) since totalCycles represents COMPLETED cycles
+ * Returns the CURRENT cycle number (same as totalCycles in cycleMetadata)
+ * The settlement job increments totalCycles when closing a cycle,
+ * so totalCycles always represents the active cycle number.
  * Returns 1 if metadata doesn't exist (e.g., during tests or first cycle)
  */
 export async function getCurrentCycleNumber(): Promise<number> {
   try {
     const metadata = await prisma.cycleMetadata.findUnique({ where: { id: 1 } });
-    // totalCycles = completed cycles, so current cycle = totalCycles + 1
-    return (metadata?.totalCycles || 0) + 1;
+    return metadata?.totalCycles || 1;
   } catch (error) {
     // If cycleMetadata table doesn't exist or query fails, return 1 (first cycle)
     logger.warn('[BattleOrchestrator] Could not fetch cycle number, defaulting to 1:', error);

--- a/prototype/backend/src/services/cycleScheduler.ts
+++ b/prototype/backend/src/services/cycleScheduler.ts
@@ -423,6 +423,22 @@ async function executeSettlement(): Promise<JobContext> {
     logger.error(`Daily Settlement: Failed to auto-generate users — ${userGenError instanceof Error ? userGenError.message : String(userGenError)}`);
   }
 
+  // Step 7: Rebalance league instances after user generation
+  // New robots from Step 6 may overflow instances or create uneven distributions
+  // (e.g., bronze_1: 98, bronze_2: 98, bronze_3: 21). Without this step,
+  // rebalanceLeagues() in the league cycle only runs hours earlier, before
+  // new users are generated, leaving new instances permanently unbalanced.
+  logger.info('Daily Settlement: Step 7 — Rebalancing league instances post-generation');
+  try {
+    const { LEAGUE_TIERS, rebalanceInstances } = await import('./leagueInstanceService');
+
+    for (const tier of LEAGUE_TIERS) {
+      await rebalanceInstances(tier);
+    }
+  } catch (rebalanceError) {
+    logger.error(`Daily Settlement: Failed to rebalance instances — ${rebalanceError instanceof Error ? rebalanceError.message : String(rebalanceError)}`);
+  }
+
   logger.info(`Daily Settlement: Completed — passive income ₡${totalPassiveIncome.toLocaleString()}, operating costs ₡${totalOperatingCosts.toLocaleString()}, ${endOfCycleUsers.length} users processed`);
 
   return { jobName: 'settlement' };

--- a/prototype/backend/src/services/leagueInstanceService.ts
+++ b/prototype/backend/src/services/leagueInstanceService.ts
@@ -79,11 +79,16 @@ export async function getLeagueInstanceStats(tier: LeagueTier): Promise<LeagueIn
   const averagePerInstance = instances.length > 0 ? totalRobots / instances.length : 0;
 
   // Check if rebalancing is needed:
-  // Only when any instance exceeds the maximum robot limit
-  // (Deviation check not needed since assignLeagueInstance fills evenly)
-  const needsRebalancing = instances.some((inst) => 
+  // 1. Any instance exceeds the maximum robot limit (overflow)
+  // 2. Significant imbalance between instances (deviation > 10 from target)
+  const hasOverflow = instances.some((inst) => 
     inst.currentRobots > MAX_ROBOTS_PER_INSTANCE
   );
+  const targetPerInstance = instances.length > 0 ? Math.ceil(totalRobots / instances.length) : 0;
+  const hasImbalance = instances.length >= 2 && instances.some((inst) =>
+    Math.abs(inst.currentRobots - targetPerInstance) > REBALANCE_THRESHOLD
+  );
+  const needsRebalancing = hasOverflow || hasImbalance;
 
   return {
     tier,

--- a/prototype/backend/src/services/leagueRebalancingService.ts
+++ b/prototype/backend/src/services/leagueRebalancingService.ts
@@ -372,19 +372,17 @@ export async function rebalanceLeagues(): Promise<FullRebalancingSummary> {
     }
   }
 
-  // Rebalance instances for each tier after all moves (ONLY if instance exceeds 100 robots)
+  // Rebalance instances for each tier after all moves
   logger.info('\n[Rebalancing] Checking instances for rebalancing...');
   for (const tier of LEAGUE_TIERS) {
     try {
       const instances = await getInstancesForTier(tier);
-      const needsRebalancing = instances.some(inst => inst.currentRobots > MAX_ROBOTS_PER_INSTANCE);
-      
-      if (needsRebalancing) {
-        logger.info(`[Rebalancing] ${tier}: Instance exceeds ${MAX_ROBOTS_PER_INSTANCE} robots, rebalancing...`);
-        await rebalanceInstances(tier);
-      } else {
-        logger.info(`[Rebalancing] ${tier}: All instances at or under ${MAX_ROBOTS_PER_INSTANCE} robots, skipping rebalancing`);
+      if (instances.length < 2) {
+        logger.info(`[Rebalancing] ${tier}: Single instance, skipping`);
+        continue;
       }
+
+      await rebalanceInstances(tier);
     } catch (error) {
       logger.error(`[Rebalancing] Error checking ${tier} instances:`, error);
     }

--- a/prototype/backend/src/utils/economyCalculations.ts
+++ b/prototype/backend/src/utils/economyCalculations.ts
@@ -636,6 +636,7 @@ export async function generatePerRobotFinancialReport(userId: number): Promise<{
     revenue: {
       battleWinnings: number;
       merchandising: number;
+      streaming: number;
       total: number;
     };
     costs: {
@@ -754,14 +755,19 @@ export async function generatePerRobotFinancialReport(userId: number): Promise<{
           robot2Id: true,
           battleType: true,
           createdAt: true,
+          participants: {
+            where: { robotId: robot.id },
+            select: { streamingRevenue: true },
+          },
         },
         orderBy: {
           createdAt: 'desc',
         },
       });
 
-      // Calculate battle winnings and build battle details array
+      // Calculate battle winnings, streaming revenue, and build battle details array
       let battleWinnings = 0;
+      let streamingRevenue = 0;
       const battleDetails = [];
 
       for (const battle of recentBattles) {
@@ -769,6 +775,12 @@ export async function generatePerRobotFinancialReport(userId: number): Promise<{
         const reward = isWinner ? (battle.winnerReward || 0) : (battle.loserReward || 0);
 
         battleWinnings += reward;
+
+        // Sum streaming revenue from battle participants
+        const participantStreaming = battle.participants?.reduce(
+          (sum, p) => sum + (p.streamingRevenue || 0), 0
+        ) || 0;
+        streamingRevenue += participantStreaming;
 
         battleDetails.push({
           id: battle.id,
@@ -792,7 +804,7 @@ export async function generatePerRobotFinancialReport(userId: number): Promise<{
       // and is not included in passive income calculations
 
       // Calculate totals
-      const totalRevenue = battleWinnings + merchandising;
+      const totalRevenue = battleWinnings + merchandising + streamingRevenue;
       const totalCosts = repairCosts + allocatedFacilityCostPerRobot;
       const netIncome = totalRevenue - totalCosts;
       const roi = totalCosts > 0 ? (netIncome / totalCosts) * 100 : 0;
@@ -816,6 +828,7 @@ export async function generatePerRobotFinancialReport(userId: number): Promise<{
         revenue: {
           battleWinnings,
           merchandising,
+          streaming: streamingRevenue,
           total: totalRevenue,
         },
         costs: {

--- a/prototype/backend/tests/leagueInstanceService.test.ts
+++ b/prototype/backend/tests/leagueInstanceService.test.ts
@@ -169,7 +169,8 @@ describe('League Instance Service', () => {
       
       expect(stats.totalRobots).toBe(100);
       expect(stats.averagePerInstance).toBe(50);
-      expect(stats.needsRebalancing).toBe(false); // Changed: needsRebalancing only true when instance > MAX_ROBOTS_PER_INSTANCE (100)
+      // Deviation of 30 exceeds REBALANCE_THRESHOLD (20), so rebalancing is needed
+      expect(stats.needsRebalancing).toBe(true);
 
       // Clean up
       await prisma.robot.deleteMany({ where: { userId: user.id } });
@@ -355,22 +356,19 @@ describe('League Instance Service', () => {
 
       await rebalanceInstances('champion');
 
-      // Since neither instance exceeds MAX_ROBOTS_PER_INSTANCE (100), rebalancing won't trigger
-      // The instances will remain as they were (80 and 20)
+      // Deviation of 30 exceeds REBALANCE_THRESHOLD (20), so rebalancing triggers
+      // Round-robin redistribution should produce 50/50 split
       const instances = await getInstancesForTier('champion');
       const totalRobots = instances.reduce(
         (sum, instance) => sum + instance.currentRobots,
         0,
       );
       expect(totalRobots).toBe(100);
-      
-      // Should still have 2 instances since rebalancing didn't trigger
       expect(instances).toHaveLength(2);
-      
-      // Verify no instance exceeds the limit
-      instances.forEach((instance) => {
-        expect(instance.currentRobots).toBeLessThanOrEqual(100);
-      });
+
+      // Each instance should have 50 robots after round-robin redistribution
+      expect(instances[0].currentRobots).toBe(50);
+      expect(instances[1].currentRobots).toBe(50);
 
       // Clean up
       await prisma.robot.deleteMany({ where: { userId: user.id } });

--- a/prototype/frontend/src/components/FinancialSummary.tsx
+++ b/prototype/frontend/src/components/FinancialSummary.tsx
@@ -75,7 +75,7 @@ function FinancialSummary() {
         </div>
 
         {/* Daily Net Income */}
-        <div className="pb-3 border-b border-white/10">
+        <div className="pb-3">
           <div className="text-xs text-secondary mb-1">Daily Passive Net</div>
           <div className={`text-lg font-bold ${isPositive ? 'text-success' : 'text-error'}`}>
             {isPositive ? '+' : ''}{formatCurrency(summary.netPassiveIncome)}

--- a/prototype/frontend/src/pages/LeagueStandingsPage.tsx
+++ b/prototype/frontend/src/pages/LeagueStandingsPage.tsx
@@ -229,16 +229,16 @@ function LeagueStandingsPage() {
           <>
             <div className="bg-surface rounded-lg overflow-hidden">
               <div className="overflow-x-auto scrollbar-thin">
-                <table className="w-full min-w-[600px]">
+                <table className="w-full">
                   <thead className="bg-surface-elevated">
                     <tr>
-                      <th className="px-2 lg:px-4 py-3 text-left font-semibold">Rank</th>
-                      <th className="px-2 lg:px-4 py-3 text-left font-semibold">Robot</th>
-                      <th className="px-2 lg:px-4 py-3 text-left font-semibold">Owner</th>
-                      <th className="px-2 lg:px-4 py-3 text-center font-semibold">ELO</th>
-                      <th className="hidden lg:table-cell px-4 py-3 text-center font-semibold">LP</th>
+                      <th className="px-1.5 lg:px-4 py-3 text-left font-semibold text-sm lg:text-base">#</th>
+                      <th className="px-1.5 lg:px-4 py-3 text-left font-semibold text-sm lg:text-base">Robot</th>
+                      <th className="px-1.5 lg:px-4 py-3 text-left font-semibold text-sm lg:text-base">Owner</th>
+                      <th className="px-1.5 lg:px-4 py-3 text-center font-semibold text-sm lg:text-base">LP</th>
+                      <th className="px-1.5 lg:px-4 py-3 text-center font-semibold text-sm lg:text-base">ELO</th>
                       <th className="hidden lg:table-cell px-4 py-3 text-center font-semibold">Fame</th>
-                      <th className="px-2 lg:px-4 py-3 text-center font-semibold">W-D-L</th>
+                      <th className="hidden lg:table-cell px-4 py-3 text-center font-semibold">W-D-L</th>
                       <th className="hidden lg:table-cell px-4 py-3 text-center font-semibold">Win Rate</th>
                     </tr>
                   </thead>
@@ -259,30 +259,32 @@ function LeagueStandingsPage() {
                             isMyBot ? 'bg-blue-900 bg-opacity-30' : 'hover:bg-surface-elevated'
                           } transition-colors`}
                         >
-                          <td className={`px-2 lg:px-4 py-3 font-bold ${rankColor}`}>
+                          <td className={`px-1.5 lg:px-4 py-3 font-bold ${rankColor} text-sm lg:text-base`}>
                             #{rank}
                           </td>
-                          <td className="px-2 lg:px-4 py-3">
-                            <div className={`font-semibold ${isMyBot ? 'text-primary' : ''}`}>
+                          <td className="px-1.5 lg:px-4 py-3">
+                            <div className={`font-semibold text-sm lg:text-base truncate max-w-[100px] lg:max-w-none ${isMyBot ? 'text-primary' : ''}`}>
                               {robot.name}
                             </div>
                           </td>
-                          <td className="px-2 lg:px-4 py-3 text-secondary">
-                            {robot.user.stableName || robot.user.username}
+                          <td className="px-1.5 lg:px-4 py-3 text-secondary text-sm lg:text-base">
+                            <span className="truncate block max-w-[80px] lg:max-w-none">
+                              {robot.user.stableName || robot.user.username}
+                            </span>
                             {isMyBot && (
-                              <span className="ml-2 text-xs bg-primary px-2 py-1 rounded">
+                              <span className="ml-1 text-xs bg-primary px-1.5 py-0.5 rounded">
                                 YOU
                               </span>
                             )}
                           </td>
-                          <td className="px-2 lg:px-4 py-3 text-center font-mono">{robot.elo}</td>
-                          <td className="hidden lg:table-cell px-4 py-3 text-center font-mono text-warning">
+                          <td className="px-1.5 lg:px-4 py-3 text-center font-mono text-sm lg:text-base text-warning">
                             {robot.leaguePoints}
                           </td>
+                          <td className="px-1.5 lg:px-4 py-3 text-center font-mono text-sm lg:text-base">{robot.elo}</td>
                           <td className="hidden lg:table-cell px-4 py-3 text-center font-mono text-purple-400">
                             {robot.fame}
                           </td>
-                          <td className="px-2 lg:px-4 py-3 text-center font-mono">
+                          <td className="hidden lg:table-cell px-4 py-3 text-center font-mono">
                             <span className="text-success">{robot.wins}</span>
                             <span className="text-tertiary"> - </span>
                             <span className="text-warning">{robot.draws}</span>


### PR DESCRIPTION
… revenue, UI fixes

- League rebalancing: detect imbalance via deviation threshold, not just overflow
- Cycle number: getCurrentCycleNumber() returns totalCycles (not +1) to match settlement
- Bulk cycles: write totalCycles to DB at cycle start so battle orchestrators see correct value
- Per-robot financial report: include streaming revenue from BattleParticipant records
- Dashboard: remove border under daily passive net
- League standings: mobile columns show Rank, Robot, Owner, LP, ELO without horizontal scroll