### PR TITLE
feat: add 50% manual repair cost reduction

### DIFF
--- a/.kiro/specs/manual-repair-cost-reduction/.config.kiro
+++ b/.kiro/specs/manual-repair-cost-reduction/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4cf89683-bec1-4588-8093-51bb0b6ead88", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/manual-repair-cost-reduction/design.md
+++ b/.kiro/specs/manual-repair-cost-reduction/design.md
@@ -1,0 +1,414 @@
+# Design Document: Manual Repair Cost Reduction
+
+## Overview
+
+This feature introduces a 50% discount on manual robot repairs (triggered via the "Repair All" button on the robots page) while keeping automatic pre-battle repairs at full price. The goal is to incentivize active player engagement between cycles.
+
+The change touches four layers:
+1. **Backend cost calculation** — Apply `Math.floor(cost * 0.5)` after all existing discounts in the `POST /api/robots/repair-all` endpoint
+2. **Frontend display** — Show the manual discount as a separate line item in the repair confirmation modal and on the button label
+3. **Audit logging** — Distinguish manual vs automatic repairs with a `repairType` field and log the manual discount metadata
+4. **Admin frontend** — New "Repair Log" tab in the Admin Portal to view, filter, and summarize manual vs automatic repair activity
+
+The discount is applied as a final multiplier after Repair Bay and Medical Bay discounts, ensuring it stacks cleanly with the existing discount pipeline.
+
+## Architecture
+
+The feature modifies the existing repair cost pipeline without introducing new services or database tables.
+
+```mermaid
+flowchart TD
+    A[Player clicks Repair All] --> B[POST /api/robots/repair-all]
+    B --> C[Calculate base cost per robot]
+    C --> D[Apply Repair Bay discount]
+    D --> E[Apply 50% manual discount]
+    E --> F[Math.floor final cost]
+    F --> G{Currency >= cost?}
+    G -->|Yes| H[Execute repairs in transaction]
+    G -->|No| I[Return insufficient credits error with discounted amount]
+    H --> J[Log audit event with repairType: manual]
+    H --> K[Return response with discount breakdown]
+
+    L[Cycle Scheduler] --> M[repairAllRobots true]
+    M --> N[Calculate base cost per robot]
+    N --> O[Apply Repair Bay discount]
+    O --> P[No manual discount applied]
+    P --> Q[Log audit event with repairType: automatic]
+```
+
+### Key Design Decision: Where to Apply the Discount
+
+The manual repair endpoint (`POST /api/robots/repair-all` in `robots.ts`) uses a simpler `REPAIR_COST_PER_HP = 50` formula, while the automatic repair path (`repairAllRobots()` in `repairService.ts`) uses the full `calculateRepairCost()` formula with attribute sums, damage multipliers, and Medical Bay reductions.
+
+The 50% manual discount is applied in the endpoint handler (`robots.ts`) after the existing Repair Bay discount calculation, not inside `calculateRepairCost()`. This keeps the shared utility function unchanged and avoids any risk to the automatic repair path.
+
+### Key Design Decision: Discount Stacking Order
+
+The discount order is: Base Cost → Repair Bay discount → 50% manual discount → `Math.floor`. This means the manual discount is multiplicative on top of the Repair Bay discount, not additive. A player with 90% Repair Bay discount pays `Math.floor(baseCost * 0.10 * 0.50)` = 5% of base cost for manual repairs.
+
+## Components and Interfaces
+
+### Backend Changes
+
+#### 1. `POST /api/robots/repair-all` endpoint (`prototype/backend/src/routes/robots.ts`)
+
+Current flow calculates `finalCost = Math.floor(totalBaseCost * (1 - discount / 100))`. The change adds:
+
+```typescript
+const MANUAL_REPAIR_DISCOUNT = 0.5;
+const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100));
+const finalCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
+```
+
+Updated response payload:
+
+```typescript
+interface RepairAllResponse {
+  success: boolean;
+  repairedCount: number;
+  totalBaseCost: number;          // Before any discounts
+  discount: number;               // Repair Bay discount percentage
+  manualRepairDiscount: number;   // 50 (percentage)
+  preDiscountCost: number;        // Cost after Repair Bay but before manual discount
+  finalCost: number;              // After all discounts, Math.floor'd
+  newCurrency: number;
+  message: string;
+}
+```
+
+#### 2. `EventLogger.logRobotRepair()` (`prototype/backend/src/services/eventLogger.ts`)
+
+Add optional parameters for repair type metadata:
+
+```typescript
+async logRobotRepair(
+  userId: number,
+  robotId: number,
+  cost: number,
+  damageRepaired: number,
+  discountPercent: number,
+  cycleNumber?: number,
+  repairType?: 'manual' | 'automatic',
+  manualRepairDiscount?: number,
+  preDiscountCost?: number
+): Promise<void>
+```
+
+The audit log payload becomes:
+
+```typescript
+{
+  cost: number;
+  damageRepaired: number;
+  discountPercent: number;
+  repairType: 'manual' | 'automatic';       // NEW
+  manualRepairDiscount?: number;             // NEW — only for manual
+  preDiscountCost?: number;                  // NEW — only for manual
+}
+```
+
+#### 3. `repairAllRobots()` (`prototype/backend/src/services/repairService.ts`)
+
+Pass `repairType: 'automatic'` to `eventLogger.logRobotRepair()`. No cost calculation changes.
+
+#### 4. Admin audit log filtering (`prototype/backend/src/routes/admin.ts`)
+
+Add a new endpoint or query parameter to filter `robot_repair` events by `repairType`:
+
+```typescript
+// GET /api/admin/audit-log/repairs?repairType=manual&startDate=...&endDate=...
+interface RepairAuditQuery {
+  repairType?: 'manual' | 'automatic';
+  startDate?: string;   // ISO date
+  endDate?: string;     // ISO date
+  page?: number;
+  limit?: number;
+}
+```
+
+Response includes: `userId`, `stableName`, `robotId`, `robotName`, `repairType`, `cost`, `preDiscountCost`, `manualRepairDiscount`, `eventTimestamp`.
+
+### Frontend Changes
+
+#### 5. `RobotsPage.tsx` (`prototype/frontend/src/pages/RobotsPage.tsx`)
+
+Update `calculateTotalRepairCost()` to apply the 50% manual discount:
+
+```typescript
+const MANUAL_REPAIR_DISCOUNT = 0.5;
+const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100));
+const discountedCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
+```
+
+Update the button label to show the discounted cost (already does, just needs the new calculation).
+
+Update the confirmation modal to show a discount breakdown:
+- Repair Bay Discount: X% off
+- Manual Repair Discount: 50% off
+- Final Cost: ₡Y
+
+#### 6. `RepairLogTab.tsx` (`prototype/frontend/src/components/admin/RepairLogTab.tsx`)
+
+New admin tab component that gives admins visibility into manual vs automatic repair activity. Follows the same patterns as `BankruptcyMonitorTab` and `RecentUsersTab` (fetch on mount, loading/error states, summary cards + data table).
+
+**Data source:** `GET /api/admin/audit-log/repairs` (backend component #4 above).
+
+**Summary stats bar** (top of tab, grid of cards matching `BankruptcyMonitorTab` style):
+
+| Stat | Description |
+|---|---|
+| Total Manual Repairs | Count of events where `repairType === 'manual'` in the current query |
+| Total Automatic Repairs | Count of events where `repairType === 'automatic'` in the current query |
+| Total Savings | Sum of `(preDiscountCost - cost)` across all manual repair events in the current query |
+
+**Filters** (row below summary, above table):
+
+| Filter | Control | Default |
+|---|---|---|
+| Repair Type | `<select>` with options: All, Manual, Automatic | All |
+| Start Date | `<input type="date">` | 7 days ago |
+| End Date | `<input type="date">` | today |
+
+Changing any filter triggers a re-fetch from the API with the corresponding query parameters (`repairType`, `startDate`, `endDate`).
+
+**Data table columns:**
+
+| Column | Source field | Notes |
+|---|---|---|
+| Player | `stableName` | Displayed as primary text |
+| Robot | `robotName` | — |
+| Repair Type | `repairType` | Badge-styled: green for manual, gray for automatic |
+| Cost | `cost` | Formatted as `₡X` |
+| Pre-Discount Cost | `preDiscountCost` | Formatted as `₡X`, shown as `—` for automatic repairs |
+| Savings | `preDiscountCost - cost` | Formatted as `₡X`, shown as `—` for automatic repairs |
+| Timestamp | `eventTimestamp` | Formatted with `toLocaleString()` |
+
+**Pagination:** Uses `page` and `limit` query params (default limit 25), with Previous/Next buttons matching existing admin table patterns.
+
+**Component structure:**
+
+```typescript
+interface RepairLogEvent {
+  userId: number;
+  stableName: string;
+  robotId: number;
+  robotName: string;
+  repairType: 'manual' | 'automatic';
+  cost: number;
+  preDiscountCost: number | null;
+  manualRepairDiscount: number | null;
+  eventTimestamp: string;
+}
+
+interface RepairLogResponse {
+  events: RepairLogEvent[];
+  summary: {
+    totalManualRepairs: number;
+    totalAutomaticRepairs: number;
+    totalSavings: number;
+  };
+  pagination: {
+    page: number;
+    limit: number;
+    totalEvents: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
+}
+```
+
+**State management:** Local state via `useState` for filters, data, loading, and error — same pattern as other admin tabs. No global context needed.
+
+#### 7. `AdminPage.tsx` (`prototype/frontend/src/pages/AdminPage.tsx`)
+
+Register the new tab in the admin page shell:
+
+- Add `'repair-log'` to the `TabType` union and `VALID_TABS` array
+- Add `'repair-log': '🔧 Repair Log'` to `TAB_LABELS`
+- Import `RepairLogTab` from `../components/admin`
+- Add the tab panel rendering block for `activeTab === 'repair-log'`
+
+```typescript
+// Updated type
+type TabType = 'dashboard' | 'cycles' | 'tournaments' | 'battles' | 'stats'
+  | 'bankruptcy-monitor' | 'recent-users' | 'repair-log';
+
+// Updated VALID_TABS (repair-log added at end)
+const VALID_TABS: TabType[] = [
+  'dashboard', 'cycles', 'tournaments', 'battles', 'stats',
+  'bankruptcy-monitor', 'recent-users', 'repair-log',
+];
+
+// Updated TAB_LABELS
+const TAB_LABELS: Record<TabType, string> = {
+  // ...existing entries...
+  'repair-log': '🔧 Repair Log',
+};
+```
+
+#### 8. Admin barrel export (`prototype/frontend/src/components/admin/index.ts`)
+
+Add `export { RepairLogTab } from './RepairLogTab';` to the barrel file.
+
+#### 9. Admin types (`prototype/frontend/src/components/admin/types.ts`)
+
+Add `RepairLogEvent` and `RepairLogResponse` interfaces (shown in component #6 above) to the shared types file so they are co-located with other admin type definitions.
+
+## Data Models
+
+### No Schema Changes Required
+
+The feature does not require database migrations. The `auditLog` table already stores a flexible JSON `payload` field, which will carry the new `repairType`, `manualRepairDiscount`, and `preDiscountCost` fields.
+
+### Audit Log Payload Structure (Updated)
+
+For manual repairs:
+```json
+{
+  "cost": 2500,
+  "damageRepaired": 150,
+  "discountPercent": 14,
+  "repairType": "manual",
+  "manualRepairDiscount": 50,
+  "preDiscountCost": 5000
+}
+```
+
+For automatic repairs:
+```json
+{
+  "cost": 5000,
+  "damageRepaired": 150,
+  "discountPercent": 14,
+  "repairType": "automatic"
+}
+```
+
+### Constants
+
+```typescript
+// New constant in robots.ts endpoint
+const MANUAL_REPAIR_DISCOUNT = 0.5;  // 50% reduction
+
+// Existing constant (unchanged)
+const REPAIR_COST_PER_HP = 50;
+```
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+The following properties were derived from the acceptance criteria prework analysis. Redundant criteria were consolidated (e.g., 1.2 is subsumed by 1.1; 2.2/2.3 are subsumed by 2.1; 4.2 is subsumed by 4.1). Requirement 6 criteria are meta-requirements about test coverage and do not produce properties themselves — they are satisfied by implementing the properties below.
+
+### Property 1: Manual discount formula
+
+*For any* valid base repair cost (non-negative integer) and any Repair Bay discount percentage (0–90), the manual repair final cost shall equal `Math.floor(Math.floor(baseCost * (1 - repairBayDiscount / 100)) * 0.5)`.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 3.1**
+
+### Property 2: Automatic repair cost unchanged
+
+*For any* valid attribute sum (positive), damage percentage (0–100), HP percentage (0–100), Repair Bay level (0–10), Medical Bay level (0–10), and active robot count (1–20), the automatic repair cost shall equal the result of `calculateRepairCost(sumOfAllAttributes, damagePercent, hpPercent, repairBayLevel, medicalBayLevel, activeRobotCount)` with no additional multiplier applied.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 3: Currency validation uses discounted cost
+
+*For any* player currency value and any manual repair cost, the repair shall be allowed if and only if the player's currency is greater than or equal to the discounted final cost (after the 50% manual discount). When rejected, the error's `required` field shall equal the discounted cost.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 4: Manual cost is at most automatic cost
+
+*For any* valid repair inputs, the manual repair cost shall be less than or equal to the automatic repair cost computed from the same inputs.
+
+**Validates: Requirements 1.1, 6.5**
+
+### Property 5: Manual cost is non-negative
+
+*For any* valid repair inputs (non-negative base cost, valid discount percentages), the manual repair cost shall be greater than or equal to zero.
+
+**Validates: Requirements 1.1, 6.6**
+
+### Property 6: Repair type correctly tagged in audit log
+
+*For any* repair event, if the repair was triggered via the `POST /api/robots/repair-all` endpoint then the audit log payload's `repairType` field shall be `"manual"`, and if the repair was triggered via `repairAllRobots()` during cycle processing then the `repairType` field shall be `"automatic"`.
+
+**Validates: Requirements 7.1, 7.2**
+
+## Error Handling
+
+### Backend
+
+| Scenario | HTTP Status | Error Response |
+|---|---|---|
+| No robots need repair | 400 | `{ error: "No robots need repair" }` |
+| Insufficient credits (after manual discount) | 400 | `{ error: "Insufficient credits", required: <discountedCost>, current: <playerCurrency> }` |
+| User not found | 404 | `{ error: "User not found" }` |
+| Audit log write failure | N/A (non-blocking) | Log error, continue with repair — repair should not fail because logging failed |
+| Invalid repairType filter on admin endpoint | 400 | `{ error: "Invalid repairType. Must be 'manual' or 'automatic'" }` |
+
+The currency check must use the discounted cost (Property 3). The existing error format is preserved — only the `required` amount changes to reflect the discount.
+
+### Frontend
+
+- If the API call fails, show a generic error alert (existing behavior, unchanged)
+- If the response contains `manualRepairDiscount`, display it in the modal; if absent (backward compatibility), omit the line item
+- The `calculateTotalRepairCost()` function applies the 50% discount locally so the button label is always accurate without an API call
+
+## Testing Strategy
+
+### Property-Based Tests (fast-check)
+
+Each correctness property maps to a single property-based test with minimum 100 iterations. Tests go in `prototype/backend/tests/manualRepairDiscount.property.test.ts`.
+
+| Test | Property | Generator Strategy |
+|---|---|---|
+| Manual discount formula | Property 1 | `fc.nat(1_000_000)` for baseCost, `fc.integer({min:0, max:90})` for repairBayDiscount |
+| Automatic cost unchanged | Property 2 | `fc.integer({min:1, max:500})` for attributeSum, `fc.float({min:0, max:100})` for damagePercent/hpPercent, `fc.integer({min:0, max:10})` for levels, `fc.integer({min:1, max:20})` for robotCount |
+| Currency validation threshold | Property 3 | `fc.nat(10_000_000)` for currency, `fc.nat(1_000_000)` for repairCost |
+| Manual <= automatic | Property 4 | Same generators as Property 1 |
+| Manual cost non-negative | Property 5 | Same generators as Property 1 |
+| Repair type tagging | Property 6 | `fc.constantFrom('manual', 'automatic')` for repairType, verify payload field matches |
+
+Each test must be tagged with a comment:
+```typescript
+// Feature: manual-repair-cost-reduction, Property 1: Manual discount formula
+```
+
+### Unit Tests
+
+Unit tests go in `prototype/backend/tests/manualRepairDiscount.test.ts`. Focus on specific examples and edge cases:
+
+- 50% discount applied to a known cost (e.g., base 10000, no Repair Bay → final 5000)
+- Odd cost rounds down (e.g., base 10001, no Repair Bay → `Math.floor(10001 * 0.5)` = 5000)
+- Repair Bay 90% + manual 50% stacking (e.g., base 100000 → after 90% = 10000 → after 50% = 5000)
+- Repair Bay 0% + manual 50% (edge case from Req 1.3)
+- Zero damage → zero cost (no discount needed)
+- API response contains `manualRepairDiscount` field
+- API response contains `preDiscountCost` field
+- Insufficient credits error uses discounted cost in `required` field
+
+### Regression Tests
+
+- Verify `calculateRepairCost()` output is unchanged for a set of known input/output pairs (snapshot test)
+- Verify `repairAllRobots(true)` does not apply any manual discount (mock eventLogger, check no `manualRepairDiscount` in payload)
+
+### Frontend Tests
+
+- `calculateTotalRepairCost()` returns the correct discounted value
+- Confirmation modal shows both Repair Bay and manual discount line items
+- Button label shows discounted cost
+- Button disabled when no repairs needed (unchanged behavior)
+
+### Admin Frontend Tests (`RepairLogTab`)
+
+- Renders summary stats (total manual, total automatic, total savings) from API response
+- Renders table rows with correct columns (Player, Robot, Repair Type, Cost, Pre-Discount Cost, Savings, Timestamp)
+- Repair type filter triggers re-fetch with correct `repairType` query param
+- Date range filter triggers re-fetch with correct `startDate`/`endDate` query params
+- Shows `—` for Pre-Discount Cost and Savings columns on automatic repair rows
+- Pagination controls advance page and re-fetch
+- Loading state shown while fetching
+- Error state shown with retry button on API failure

--- a/.kiro/specs/manual-repair-cost-reduction/requirements.md
+++ b/.kiro/specs/manual-repair-cost-reduction/requirements.md
@@ -1,0 +1,96 @@
+# Requirements Document
+
+## Introduction
+
+This feature reduces the cost of all manual robot repairs by 50%. When a player clicks "Repair All" on the robots page, the final cost (after all existing discounts) is halved. Automatic repairs triggered during cycle processing (before league, tag team, and tournament battles) remain at full price. This change encourages players to actively manage their roster between cycles rather than relying solely on automatic pre-battle repairs.
+
+## Glossary
+
+- **Manual_Repair**: A repair initiated by the player via the "Repair All" button on the robots page, calling the `POST /api/robots/repair-all` endpoint.
+- **Automatic_Repair**: A repair triggered by the cycle scheduler before league, tag team, or tournament battles via `repairAllRobots(true)` in `cycleScheduler.ts`.
+- **Repair_Cost_System**: The backend system that calculates repair costs using base attribute sums, damage percentages, HP-based multipliers, and Repair Bay discounts.
+- **Manual_Repair_Discount**: A fixed 50% reduction applied to the final cost of manual repairs, applied after all other discounts (Repair Bay, Medical Bay).
+- **Repair_Bay**: A player facility that provides a percentage discount on repair costs. Discount formula: `Level × (5 + activeRobotCount)`, capped at 90%.
+- **Frontend_Cost_Display**: The cost shown to the player on the "Repair All" button and in the repair confirmation modal on the robots page.
+- **Test_Suite**: The Jest test suite with fast-check property-based testing library used to verify backend repair cost calculations and discount logic.
+- **Audit_Log**: The `auditLog` database table that records game events including repair actions, with `eventType`, `userId`, `payload`, and `eventTimestamp` fields.
+- **Admin_Panel**: The admin interface accessible via `/api/admin` routes that allows administrators to query and inspect game events and player activity.
+
+## Requirements
+
+### Requirement 1: Apply 50% Discount to Manual Repair Backend Cost
+
+**User Story:** As a player, I want manual repairs to cost 50% less, so that I can save credits by actively repairing my robots between cycles.
+
+#### Acceptance Criteria
+
+1. WHEN a player triggers a manual repair via the `POST /api/robots/repair-all` endpoint, THE Repair_Cost_System SHALL multiply the final cost (after Repair Bay discount) by 0.5 and round down to the nearest integer.
+2. WHEN a player triggers a manual repair, THE Repair_Cost_System SHALL apply the Manual_Repair_Discount after all existing discounts (Repair Bay discount, Medical Bay multiplier reduction).
+3. WHEN a player triggers a manual repair with a Repair Bay discount of 0%, THE Repair_Cost_System SHALL still apply the 50% Manual_Repair_Discount to the base cost.
+4. THE `POST /api/robots/repair-all` endpoint SHALL return the Manual_Repair_Discount percentage in its response payload alongside the existing `discount` and `finalCost` fields.
+
+### Requirement 2: Preserve Automatic Repair Costs
+
+**User Story:** As a game designer, I want automatic pre-battle repairs to remain at full price, so that the economy balance for cycle processing is not affected.
+
+#### Acceptance Criteria
+
+1. WHILE the cycle scheduler is executing league, tag team, or tournament battle processing, THE Repair_Cost_System SHALL calculate repair costs without applying the Manual_Repair_Discount.
+2. THE `repairAllRobots()` function in `repairService.ts` SHALL continue to use the existing cost formula without any manual repair discount.
+3. WHEN the cycle scheduler calls `repairAllRobots(true)`, THE Repair_Cost_System SHALL produce identical costs to the current implementation.
+
+### Requirement 3: Update Frontend Cost Display
+
+**User Story:** As a player, I want to see the correct discounted repair cost on the robots page, so that I know exactly how much I will pay before confirming.
+
+#### Acceptance Criteria
+
+1. THE Frontend_Cost_Display SHALL show the repair cost with the 50% Manual_Repair_Discount already applied on the "Repair All" button label.
+2. THE Frontend_Cost_Display SHALL show the 50% Manual_Repair_Discount in the repair confirmation modal so the player understands the discount breakdown.
+3. WHEN the player has a Repair Bay discount active, THE Frontend_Cost_Display SHALL show both the Repair Bay discount percentage and the 50% manual repair discount as separate line items in the confirmation modal.
+4. WHEN no robots need repair, THE Frontend_Cost_Display SHALL continue to disable the "Repair All" button regardless of the Manual_Repair_Discount.
+
+### Requirement 4: Currency Validation with Discounted Cost
+
+**User Story:** As a player, I want the system to check my credits against the discounted price, so that I am not blocked from repairing when I can afford the reduced cost.
+
+#### Acceptance Criteria
+
+1. WHEN a player triggers a manual repair, THE Repair_Cost_System SHALL compare the player's currency against the cost after the 50% Manual_Repair_Discount is applied.
+2. IF the player's currency is less than the discounted final cost, THEN THE Repair_Cost_System SHALL return an "Insufficient credits" error with the discounted `required` amount.
+
+### Requirement 5: Audit Logging for Manual Repair Discount
+
+**User Story:** As a game designer, I want manual repair discounts to be tracked in logs, so that I can monitor the economic impact of the discount.
+
+#### Acceptance Criteria
+
+1. WHEN a manual repair is completed, THE Repair_Cost_System SHALL log the Manual_Repair_Discount percentage alongside the existing repair event data.
+2. THE `POST /api/robots/repair-all` endpoint SHALL include the pre-discount cost and post-discount cost in its response so the savings are transparent.
+
+### Requirement 6: Test Coverage for Manual Repair Discount
+
+**User Story:** As a developer, I want comprehensive test coverage for the manual repair discount, so that I can verify the discount is applied correctly and automatic repairs remain unaffected.
+
+#### Acceptance Criteria
+
+1. THE Test_Suite SHALL include unit tests that verify the 50% Manual_Repair_Discount is applied to the final cost after all existing discounts (Repair Bay, Medical Bay).
+2. THE Test_Suite SHALL include unit tests that verify `Math.floor` rounding is applied to the discounted cost for odd-valued inputs.
+3. THE Test_Suite SHALL include regression tests that verify Automatic_Repair costs produced by `repairAllRobots(true)` remain identical to the current implementation without any Manual_Repair_Discount applied.
+4. THE Test_Suite SHALL include property-based tests using fast-check that verify FOR ALL valid attribute sums, damage percentages, and Repair Bay levels, the manual repair cost equals `Math.floor(automaticRepairCost * 0.5)`.
+5. THE Test_Suite SHALL include a property-based test using fast-check that verifies FOR ALL valid inputs, the manual repair cost is less than or equal to the automatic repair cost.
+6. THE Test_Suite SHALL include a property-based test using fast-check that verifies FOR ALL valid inputs, the manual repair cost is non-negative.
+7. WHEN a Repair Bay discount of 90% is active, THE Test_Suite SHALL verify the Manual_Repair_Discount is still applied on top of the maximum facility discount.
+
+### Requirement 7: Admin Visibility for Manual vs Automatic Repairs
+
+**User Story:** As an admin, I want to distinguish manual repairs from automatic repairs in the audit log, so that I can verify the manual repair discount is working correctly and monitor player repair behavior.
+
+#### Acceptance Criteria
+
+1. WHEN a manual repair is completed, THE Audit_Log SHALL record the `robot_repair` event with a `repairType` field set to `"manual"` in the event payload.
+2. WHEN an automatic repair is completed during cycle processing, THE Audit_Log SHALL record the `robot_repair` event with a `repairType` field set to `"automatic"` in the event payload.
+3. WHEN a manual repair is completed, THE Audit_Log SHALL include the `manualRepairDiscount` percentage and the `preDiscountCost` in the event payload alongside the existing `cost`, `damageTaken`, and `repairBayDiscount` fields.
+4. THE Admin_Panel SHALL provide an API endpoint or query parameter that allows filtering `robot_repair` audit log events by `repairType` (`"manual"` or `"automatic"`).
+5. WHEN an admin queries manual repair events, THE Admin_Panel SHALL return the player's userId, stableName, robotId, robotName, repairType, cost, preDiscountCost, manualRepairDiscount, and eventTimestamp for each event.
+6. THE Admin_Panel SHALL support filtering manual repair events by date range so admins can analyze discount usage over specific time periods.

--- a/.kiro/specs/manual-repair-cost-reduction/tasks.md
+++ b/.kiro/specs/manual-repair-cost-reduction/tasks.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Manual Repair Cost Reduction
+
+## Overview
+
+Apply a 50% discount to manual robot repairs while preserving automatic repair costs. The implementation proceeds backend-first (discount logic → audit logging → admin endpoint), then frontend (cost display → admin tab), then testing.
+
+## Tasks
+
+- [x] 1. Apply 50% manual repair discount in backend endpoint
+  - [x] 1.1 Modify `POST /api/robots/repair-all` in `prototype/backend/src/routes/robots.ts` to apply `MANUAL_REPAIR_DISCOUNT = 0.5`
+    - Add `const MANUAL_REPAIR_DISCOUNT = 0.5;` constant
+    - Change `finalCost` calculation to: `const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100)); const finalCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);`
+    - Update currency check to compare against the new discounted `finalCost`
+    - Update response payload to include `manualRepairDiscount: 50`, `preDiscountCost: costAfterRepairBay`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 4.1, 4.2_
+
+  - [x] 1.2 Write property tests for manual discount formula
+    - **Property 1: Manual discount formula** — For any valid base cost and Repair Bay discount (0–90), manual cost equals `Math.floor(Math.floor(baseCost * (1 - repairBayDiscount / 100)) * 0.5)`
+    - **Validates: Requirements 1.1, 1.2, 1.3, 3.1**
+    - Create `prototype/backend/tests/manualRepairDiscount.property.test.ts`
+    - Use `fc.nat(1_000_000)` for baseCost, `fc.integer({min:0, max:90})` for repairBayDiscount
+
+  - [x] 1.3 Write property tests for manual cost bounds
+    - **Property 4: Manual cost ≤ automatic cost** — For any valid inputs, manual cost is at most the automatic cost
+    - **Property 5: Manual cost non-negative** — For any valid inputs, manual cost ≥ 0
+    - **Validates: Requirements 1.1, 6.5, 6.6**
+    - Add to `prototype/backend/tests/manualRepairDiscount.property.test.ts`
+
+  - [x] 1.4 Write unit tests for manual repair discount
+    - Create `prototype/backend/tests/manualRepairDiscount.test.ts`
+    - Test 50% discount on known cost (base 10000, no Repair Bay → 5000)
+    - Test odd cost rounds down (base 10001 → `Math.floor(10001 * 0.5)` = 5000)
+    - Test Repair Bay 90% + manual 50% stacking (base 100000 → 10000 → 5000)
+    - Test Repair Bay 0% + manual 50% (edge case from Req 1.3)
+    - Test zero damage → zero cost
+    - Test response contains `manualRepairDiscount` and `preDiscountCost` fields
+    - Test insufficient credits error uses discounted cost in `required` field
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 4.1, 4.2, 6.1, 6.2, 6.7_
+
+- [x] 2. Update audit logging with repairType field
+  - [x] 2.1 Extend `EventLogger.logRobotRepair()` in `prototype/backend/src/services/eventLogger.ts`
+    - Add optional parameters: `repairType?: 'manual' | 'automatic'`, `manualRepairDiscount?: number`, `preDiscountCost?: number`
+    - Include `repairType`, `manualRepairDiscount`, and `preDiscountCost` in the audit log payload when provided
+    - _Requirements: 5.1, 7.1, 7.2, 7.3_
+
+  - [x] 2.2 Pass `repairType: 'manual'` from `POST /api/robots/repair-all` in `prototype/backend/src/routes/robots.ts`
+    - Call `eventLogger.logRobotRepair()` for each repaired robot with `repairType: 'manual'`, `manualRepairDiscount: 50`, and `preDiscountCost`
+    - _Requirements: 5.1, 5.2, 7.1, 7.3_
+
+  - [x] 2.3 Pass `repairType: 'automatic'` from `repairAllRobots()` in `prototype/backend/src/services/repairService.ts`
+    - Update the existing `eventLogger.logRobotRepair()` call to include `repairType: 'automatic'`
+    - No cost calculation changes — automatic repairs remain at full price
+    - _Requirements: 2.1, 2.2, 2.3, 7.2_
+
+  - [x] 2.4 Write property test for repair type tagging
+    - **Property 6: Repair type correctly tagged** — Manual endpoint logs `repairType: "manual"`, automatic path logs `repairType: "automatic"`
+    - **Validates: Requirements 7.1, 7.2**
+    - Add to `prototype/backend/tests/manualRepairDiscount.property.test.ts`
+
+  - [x] 2.5 Write property test for automatic repair cost unchanged
+    - **Property 2: Automatic repair cost unchanged** — For any valid inputs, `calculateRepairCost()` output is identical with no manual discount applied
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+    - Add to `prototype/backend/tests/manualRepairDiscount.property.test.ts`
+
+  - [x] 2.6 Write regression unit tests for automatic repair path
+    - Add to `prototype/backend/tests/manualRepairDiscount.test.ts`
+    - Verify `calculateRepairCost()` output unchanged for known input/output pairs
+    - Verify `repairAllRobots(true)` does not include `manualRepairDiscount` in audit payload
+    - _Requirements: 2.1, 2.2, 2.3, 6.3_
+
+- [x] 3. Checkpoint — Ensure all backend tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Add admin audit log endpoint for repair filtering
+  - [x] 4.1 Create `GET /api/admin/audit-log/repairs` endpoint in `prototype/backend/src/routes/admin.ts`
+    - Accept query params: `repairType` (manual|automatic), `startDate`, `endDate`, `page`, `limit`
+    - Query `auditLog` table for `eventType: 'robot_repair'`, filter by `repairType` in JSON payload
+    - Join with `user` table for `stableName` and `robot` table for `robotName`
+    - Return `RepairLogResponse` with events array, summary stats (totalManualRepairs, totalAutomaticRepairs, totalSavings), and pagination
+    - Validate `repairType` param, return 400 for invalid values
+    - _Requirements: 7.4, 7.5, 7.6_
+
+  - [x] 4.2 Write property test for currency validation
+    - **Property 3: Currency validation uses discounted cost** — Repair allowed iff currency ≥ discounted cost; error `required` field equals discounted cost
+    - **Validates: Requirements 4.1, 4.2**
+    - Add to `prototype/backend/tests/manualRepairDiscount.property.test.ts`
+
+- [x] 5. Update frontend cost display on robots page
+  - [x] 5.1 Update `calculateTotalRepairCost()` and button label in `prototype/frontend/src/pages/RobotsPage.tsx`
+    - Add `const MANUAL_REPAIR_DISCOUNT = 0.5;`
+    - Apply `Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT)` to the displayed cost
+    - Button label shows the discounted cost
+    - _Requirements: 3.1, 3.4_
+
+  - [x] 5.2 Update repair confirmation modal in `prototype/frontend/src/pages/RobotsPage.tsx`
+    - Show discount breakdown: Repair Bay discount %, Manual Repair Discount 50%, Final Cost
+    - When Repair Bay discount is active, show both as separate line items
+    - _Requirements: 3.2, 3.3_
+
+- [x] 6. Build admin Repair Log tab
+  - [x] 6.1 Add `RepairLogEvent` and `RepairLogResponse` interfaces to `prototype/frontend/src/components/admin/types.ts`
+    - Define interfaces matching the backend response shape from task 4.1
+    - _Requirements: 7.5_
+
+  - [x] 6.2 Create `RepairLogTab` component in `prototype/frontend/src/components/admin/RepairLogTab.tsx`
+    - Summary stats bar: Total Manual Repairs, Total Automatic Repairs, Total Savings
+    - Filters: Repair Type select (All/Manual/Automatic), Start Date, End Date
+    - Data table columns: Player, Robot, Repair Type (badge), Cost, Pre-Discount Cost, Savings, Timestamp
+    - Pagination with Previous/Next buttons (default limit 25)
+    - Loading and error states following existing admin tab patterns
+    - _Requirements: 7.4, 7.5, 7.6_
+
+  - [x] 6.3 Register `RepairLogTab` in `prototype/frontend/src/pages/AdminPage.tsx`
+    - Add `'repair-log'` to `TabType` union and `VALID_TABS` array
+    - Add `'repair-log': '🔧 Repair Log'` to `TAB_LABELS`
+    - Import `RepairLogTab` from `../components/admin`
+    - Add tab panel rendering block for `activeTab === 'repair-log'`
+    - _Requirements: 7.4_
+
+  - [x] 6.4 Export `RepairLogTab` from `prototype/frontend/src/components/admin/index.ts`
+    - Add `export { RepairLogTab } from './RepairLogTab';` to barrel file
+    - _Requirements: 7.4_
+
+- [x] 7. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The discount is applied as a final multiplier after all existing discounts (Repair Bay, Medical Bay)

--- a/docs/guides/ADMIN_PANEL_GUIDE.md
+++ b/docs/guides/ADMIN_PANEL_GUIDE.md
@@ -4,7 +4,7 @@
 
 The Admin Panel provides tools for managing the game's daily cycle, tournaments, battles, and system operations. Access it at `/admin` (requires admin role).
 
-The panel is organized into 7 tabs:
+The panel is organized into 8 tabs:
 1. **Dashboard** — System statistics overview with integrated System Health monitoring
 2. **Cycle Controls** — Run matchmaking, battles, rebalancing, repairs, and bulk cycles
 3. **Tournaments** — Create and manage competitive tournaments
@@ -12,6 +12,7 @@ The panel is organized into 7 tabs:
 5. **Robot Stats** — Statistical analysis, outlier detection, and performance analytics
 6. **Bankruptcy Monitor** — Monitor users at risk of bankruptcy (always visible)
 7. **Recent Users** — Recent real users with onboarding status and issue detection
+8. **Repair Log** — View and filter manual vs automatic repair activity with savings tracking
 
 ## Component Architecture
 
@@ -25,6 +26,7 @@ The Admin Page uses a **thin shell + tab components** pattern:
   - `RobotStatsTab.tsx`
   - `BankruptcyMonitorTab.tsx`
   - `RecentUsersTab.tsx`
+  - `RepairLogTab.tsx`
 - **Shared types** — `components/admin/types.ts` contains shared interfaces (`SystemStats`, `Battle`, `SessionLogEntry`, `RobotStats`, `AtRiskUser`, etc.)
 - **Barrel export** — `components/admin/index.ts` re-exports all tab components
 
@@ -282,6 +284,48 @@ Displays recent real users with:
 - Robot details per user
 - Issue detection flags
 - Cycle range control for filtering the time window
+
+## Repair Log Tab
+
+The Repair Log tab provides visibility into manual vs automatic repair activity across all players. It helps admins track the impact of the 50% manual repair discount.
+
+**Data Source:** `GET /api/admin/audit-log/repairs`
+
+### Summary Stats
+
+Three summary cards at the top of the tab:
+- **Total Manual Repairs** — Count of repairs triggered via the Repair All button
+- **Total Automatic Repairs** — Count of repairs triggered during cycle processing
+- **Total Savings** — Sum of credits saved from the 50% manual repair discount
+
+### Filters
+
+| Filter | Control | Default |
+|--------|---------|---------|
+| Repair Type | Select: All / Manual / Automatic | All |
+| Start Date | Date picker | 7 days ago |
+| End Date | Date picker | Today |
+
+Changing any filter triggers a re-fetch from the API.
+
+### Data Table
+
+| Column | Description |
+|--------|-------------|
+| Player | Stable name |
+| Robot | Robot name |
+| Repair Type | Badge-styled: green for manual, gray for automatic |
+| Cost | Final cost paid (₡X) |
+| Pre-Discount Cost | Cost before manual discount (₡X), shown as `—` for automatic repairs |
+| Savings | Credits saved from manual discount (₡X), shown as `—` for automatic repairs |
+| Timestamp | When the repair occurred |
+
+Pagination with Previous/Next buttons (default 25 rows per page).
+
+**When to use:**
+- To monitor how players are using manual vs automatic repairs
+- To track the economic impact of the 50% manual repair discount
+- To identify players who are actively managing their repair costs
 
 ## Best Practices
 

--- a/docs/implementation_notes/REPAIR_COST_SYSTEM.md
+++ b/docs/implementation_notes/REPAIR_COST_SYSTEM.md
@@ -1,6 +1,6 @@
 # Repair Cost System
 
-**Last Updated**: February 17, 2026  
+**Last Updated**: March 16, 2026  
 **Status**: Authoritative Reference
 
 ## Overview
@@ -167,6 +167,47 @@ Key points:
 3. **Clear Expenses**: All expenses (repairs, purchases, operating costs) tracked consistently
 4. **Strategic Decisions**: Players can upgrade Repair Bay before repairing to save money
 5. **Audit Trail**: Complete history of all repair actions and costs
+6. **Active Play Incentive**: 50% manual repair discount rewards players who repair between cycles
+
+## Manual Repair Discount (50%)
+
+**Added**: March 16, 2026
+
+When players manually repair robots via the "Repair All" button on the `/robots` page, a 50% discount is applied on top of all existing facility discounts. Automatic repairs during cycle processing pay full price.
+
+### Discount Stacking Order
+
+```
+Base Cost → Repair Bay discount → Math.floor → 50% manual discount → Math.floor
+```
+
+```typescript
+const MANUAL_REPAIR_DISCOUNT = 0.5;
+const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100));
+const finalCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
+```
+
+The discount is multiplicative, not additive. A player with 90% Repair Bay discount pays `Math.floor(baseCost × 0.10 × 0.50)` = 5% of base cost for manual repairs.
+
+### Where the Discount is Applied
+
+- **Manual repairs** (`POST /api/robots/repair-all` in `robots.ts`): 50% discount applied after Repair Bay discount
+- **Automatic repairs** (`repairAllRobots()` in `repairService.ts`): No manual discount — full price
+
+The discount is applied in the endpoint handler, not inside `calculateRepairCost()`, to keep the shared utility function unchanged and avoid any risk to the automatic repair path.
+
+### Audit Log Differentiation
+
+Repair events now include a `repairType` field:
+- `repairType: 'manual'` — triggered via the Repair All button, includes `manualRepairDiscount: 50` and `preDiscountCost`
+- `repairType: 'automatic'` — triggered during cycle processing, no manual discount fields
+
+### Admin Repair Log
+
+A dedicated "🔧 Repair Log" tab in the Admin Panel (`GET /api/admin/audit-log/repairs`) provides:
+- Filtering by repair type (manual/automatic) and date range
+- Summary stats: total manual repairs, total automatic repairs, total savings from manual discounts
+- Detailed table with player, robot, repair type, cost, pre-discount cost, savings, and timestamp
 
 ## Implementation Details
 
@@ -182,7 +223,9 @@ Key points:
 ### Audit Logging
 - **Service**: `eventLogger.logRobotRepair()`
 - **Event Type**: `'robot_repair'`
-- **Payload**: `{ cost, robotId, damageTaken, repairBayDiscount }`
+- **Payload**: `{ cost, robotId, damageTaken, repairBayDiscount, repairType, manualRepairDiscount?, preDiscountCost? }`
+- **repairType**: `'manual'` (from Repair All button) or `'automatic'` (from cycle processing)
+- Manual repairs also include `manualRepairDiscount: 50` and `preDiscountCost` in the payload
 
 ### Cycle Aggregation
 - **Service**: `cycleSnapshotService.createSnapshot()`

--- a/docs/prd_core/BATTLE_SIMULATION_ARCHITECTURE.md
+++ b/docs/prd_core/BATTLE_SIMULATION_ARCHITECTURE.md
@@ -1,0 +1,499 @@
+# Battle Simulation Architecture
+
+**Last Updated**: March 15, 2026
+**Status**: ✅ Implemented
+**Owner**: Robert Teunissen
+**Epic**: Battle System - Simulation & Orchestration
+
+---
+
+## Executive Summary
+
+This document provides a unified architectural overview of the battle simulation system. It ties together the shared combat engine, the three battle orchestrators (league, tournament, tag team), the narrative generation pipeline, the BattleParticipant data model, and the audit log — all of which were previously documented in isolation.
+
+---
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     CYCLE SCHEDULER (cycleScheduler.ts)                 │
+│                     4 independent cron jobs via node-cron               │
+│                                                                         │
+│  ┌─────────────────────┐  ┌─────────────────────┐                      │
+│  │  LEAGUE CYCLE        │  │  TOURNAMENT CYCLE    │                      │
+│  │  cron: 0 20 * * *    │  │  cron: 0 8 * * *     │                      │
+│  │  (daily 20:00 UTC)   │  │  (daily 08:00 UTC)   │                      │
+│  │                      │  │                      │                      │
+│  │  1. Repair robots    │  │  1. Repair robots    │                      │
+│  │  2. Execute battles  │  │  2. Execute matches  │                      │
+│  │  3. Rebalance leagues│  │  3. Advance winners  │                      │
+│  │  4. Matchmaking (24h)│  │  4. Auto-create next │                      │
+│  └──────────┬───────────┘  └──────────┬───────────┘                      │
+│             │                         │                                  │
+│  ┌──────────┴──────────┐  ┌──────────┴───────────┐                      │
+│  │  TAG TEAM CYCLE      │  │  SETTLEMENT           │                      │
+│  │  cron: 0 12 * * *    │  │  cron: 0 23 * * *     │                      │
+│  │  (daily 12:00 UTC)   │  │  (daily 23:00 UTC)    │                      │
+│  │                      │  │                       │                      │
+│  │  1. Repair robots    │  │  1. Passive income    │                      │
+│  │  2. Execute battles  │  │  2. Operating costs   │                      │
+│  │     (odd cycles only)│  │  3. End-of-cycle      │                      │
+│  │  3. Rebalance leagues│  │     balance logging   │                      │
+│  │  4. Matchmaking (48h)│  │  4. Increment cycle   │                      │
+│  └──────────┬───────────┘  │  5. Analytics snapshot │                      │
+│             │              │  6. Auto-generate users│                      │
+│             │              └──────────┬────────────┘                      │
+│             │                        │                                   │
+│  Also triggered via:    POST /api/admin/cycles/bulk (manual/dev)         │
+└─────────────┼────────────────────────┼───────────────────────────────────┘
+              │                        │
+  ┌───────────▼────────────────────────▼───────────────────┐
+  │                                                         │
+  │  ┌──────────────────┐ ┌──────────────┐ ┌────────────┐  │
+  │  │ League            │ │ Tournament   │ │ Tag Team   │  │
+  │  │ Orchestrator      │ │ Orchestrator │ │ Orchestrator│  │
+  │  │ battleOrchestrator│ │ tournament   │ │ tagTeamBattle│ │
+  │  │ .ts               │ │ Battle       │ │ Orchestrator│  │
+  │  │                   │ │ Orchestrator │ │ .ts         │  │
+  │  │                   │ │ .ts          │ │             │  │
+  │  └────────┬──────────┘ └──────┬──────┘ └──────┬──────┘  │
+  │           │                   │               │          │
+  └───────────┼───────────────────┼───────────────┼──────────┘
+              │                   │               │
+        ┌─────▼───────────────────▼───────────────▼────────┐
+        │              COMBAT SIMULATOR                     │
+        │            (combatSimulator.ts)                    │
+        │                                                    │
+        │  simulateBattle(robot1, robot2, isTournament?)     │
+        │                                                    │
+        │  Returns: CombatResult                             │
+        │    ├─ winnerId                                     │
+        │    ├─ robot1FinalHP / robot2FinalHP                │
+        │    ├─ robot1Damage / robot2Damage                  │
+        │    ├─ durationSeconds                              │
+        │    ├─ isDraw                                       │
+        │    └─ events: CombatEvent[]                        │
+        └──────────────────────┬───────────────────────────┘
+                               │
+        ┌──────────────────────▼───────────────────────────┐
+        │          COMBAT MESSAGE GENERATOR                 │
+        │        (combatMessageGenerator.ts)                 │
+        │                                                    │
+        │  generateBattleLog({ simulatorEvents, ... })       │
+        │    └─ convertSimulatorEvents()  (1v1/tournament)   │
+        │    └─ convertTagTeamEvents()    (tag team)         │
+        │                                                    │
+        │  Raw CombatEvent[] → Narrative battle log          │
+        └──────────────────────┬───────────────────────────┘
+                               │
+        ┌──────────────────────▼───────────────────────────┐
+        │              DATABASE WRITES                      │
+        │                                                    │
+        │  ┌─────────────┐    ┌──────────────────────┐      │
+        │  │   Battle     │    │  BattleParticipant   │      │
+        │  │   (1 row)    │    │  (1 row per robot)   │      │
+        │  │              │    │                      │      │
+        │  │  battleType  │    │  robotId, team, role │      │
+        │  │  winnerId    │    │  eloBefore/After     │      │
+        │  │  duration    │    │  damageDealt         │      │
+        │  │  battleLog   │    │  finalHP             │      │
+        │  │  leagueType  │    │  credits             │      │
+        │  │  cycleNumber │    │  streamingRevenue    │      │
+        │  └──────┬───────┘    │  prestigeAwarded     │      │
+        │         │            │  fameAwarded         │      │
+        │         │            │  yielded/destroyed   │      │
+        │         │            └──────────┬───────────┘      │
+        └─────────┼───────────────────────┼──────────────────┘
+                  │                       │
+        ┌─────────▼───────────────────────▼──────────────────┐
+        │              AUDIT LOG (EventLogger)               │
+        │                                                    │
+        │  One event PER ROBOT (not per battle)              │
+        │                                                    │
+        │  ┌──────────────────────────────────────────┐      │
+        │  │  AuditLog record (robot 1's perspective) │      │
+        │  │  eventType: battle_complete               │      │
+        │  │  userId: robot1.userId                    │      │
+        │  │  robotId: robot1.id                       │      │
+        │  │  battleId: battle.id                      │      │
+        │  │  payload: { credits, elo, prestige, ... } │      │
+        │  └──────────────────────────────────────────┘      │
+        │  ┌──────────────────────────────────────────┐      │
+        │  │  AuditLog record (robot 2's perspective) │      │
+        │  │  (same structure, robot 2's data)        │      │
+        │  └──────────────────────────────────────────┘      │
+        │                                                    │
+        │  Tag team battles: 4 events (one per robot)        │
+        └────────────────────────────────────────────────────┘
+```
+
+---
+
+## The Three Orchestrators
+
+Each orchestrator handles a different match type but follows the same core pattern:
+
+```
+  Load robots with weapons from DB
+           │
+           ▼
+  Reset HP/Shield to max (full repair before combat)
+           │
+           ▼
+  Call simulateBattle() from combatSimulator.ts
+           │
+           ▼
+  Calculate rewards (credits, ELO, prestige, fame, streaming)
+           │
+           ▼
+  Create Battle record + BattleParticipant records
+           │
+           ▼
+  Convert CombatEvent[] → narrative via CombatMessageGenerator
+           │
+           ▼
+  Update robot stats (ELO, HP, league points)
+           │
+           ▼
+  Log audit events (one per robot) via EventLogger
+```
+
+
+### 1. League Battle Orchestrator (`battleOrchestrator.ts`)
+
+| Aspect | Detail |
+|---|---|
+| Match source | `ScheduledMatch` records (created by matchmaking in Step 8) |
+| Battle type | `"1v1"` |
+| Participants | 2 robots → 2 BattleParticipant records |
+| Bye handling | Creates a synthetic "Bye Robot" (ELO 1000), fights normally, reduced damage (8% HP loss) |
+| Draw handling | Allowed — both robots get `LEAGUE_POINTS_DRAW` (+1) |
+| Rewards | League-based credits, prestige (winner only), fame (winner + performance bonuses), streaming revenue |
+| League points | Win: +3, Loss: -1, Draw: +1 |
+| Audit event type | `battle_complete` (2 events) |
+| Cycle step | Step 4 |
+
+### 2. Tournament Battle Orchestrator (`tournamentBattleOrchestrator.ts`)
+
+| Aspect | Detail |
+|---|---|
+| Match source | `TournamentMatch` records (created by tournament bracket system) |
+| Battle type | `"tournament"` |
+| Participants | 2 robots → 2 BattleParticipant records |
+| Bye handling | Tournament byes are auto-completed at creation — no battle, no rewards, no combat |
+| Draw handling | Not allowed — `isTournament=true` flag triggers HP% tiebreaker, then deterministic fallback |
+| Rewards | Round-based tournament rewards (scale with bracket depth), prestige, fame, streaming revenue |
+| League points | Not affected |
+| Audit event type | `tournament_match` (2 events) |
+| Cycle step | Step 2 |
+
+### 3. Tag Team Battle Orchestrator (`tagTeamBattleOrchestrator.ts`)
+
+| Aspect | Detail |
+|---|---|
+| Match source | `TagTeamMatch` records |
+| Battle type | `"tag_team"` |
+| Participants | 4 robots (2 per team) → 4 BattleParticipant records |
+| Roles | `"active"` and `"reserve"` per team |
+| Tag-out mechanics | When active robot yields or is destroyed, reserve robot tags in |
+| Bye handling | Creates a synthetic bye-team with 2 robots (combined ELO 2000) |
+| Draw handling | Allowed |
+| Rewards | 2× credit multiplier, 1.6× prestige multiplier vs standard 1v1 |
+| Audit event type | `tag_team_battle` (4 events, one per robot) |
+| Cycle step | Independent scheduling |
+
+---
+
+## Combat Simulator Deep Dive
+
+The combat simulator (`combatSimulator.ts`) is the shared, stateless engine used by all three orchestrators. It has no database dependencies — it takes two `RobotWithWeapons` objects and returns a `CombatResult`.
+
+### Simulation Model
+
+```
+  Time: 0.0s                                    Time: 120.0s (max)
+  ├─────────────────────────────────────────────────┤
+  │  Tick-based simulation (100ms per tick)          │
+  │                                                  │
+  │  Each tick:                                      │
+  │    1. Regenerate shields (both robots)            │
+  │    2. Check attack cooldowns                      │
+  │    3. Perform attacks (main + offhand if dual)    │
+  │       a. Malfunction check (weapon control)       │
+  │       b. Hit chance (accuracy vs evasion)         │
+  │       c. Critical strike check                    │
+  │       d. Damage calculation (armor/penetration)   │
+  │       e. Shield → HP damage distribution          │
+  │       f. Counter-attack check (post-attack)       │
+  │    4. Check end conditions:                       │
+  │       - HP ≤ 0 → destroyed                        │
+  │       - HP < yield threshold → yield              │
+  │       - Time limit → draw (or HP tiebreaker)      │
+  └──────────────────────────────────────────────────┘
+```
+
+### Key Constants
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `SIMULATION_TICK` | 0.1s | Time resolution per tick |
+| `MAX_BATTLE_DURATION` | 120s | Maximum battle length before timeout |
+| `BASE_WEAPON_COOLDOWN` | 4s | Default attack interval |
+| `ARMOR_EFFECTIVENESS` | 1.5 | % damage reduction per armor point |
+| `PENETRATION_BONUS` | 2.0 | % damage increase per penetration above armor |
+
+### Input / Output Contract
+
+```
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│  INPUT: RobotWithWeapons ×2 │         │  OUTPUT: CombatResult       │
+│                             │         │                             │
+│  All 23 robot attributes:   │         │  winnerId: number | null    │
+│  - combatPower              │  ────►  │  robot1FinalHP              │
+│  - weaponControl            │         │  robot2FinalHP              │
+│  - accuracy, evasion        │         │  robot1Damage (taken)       │
+│  - armor, penetration       │         │  robot2Damage (taken)       │
+│  - critChance, critDamage   │         │  robot1DamageDealt          │
+│  - attackSpeed              │         │  robot2DamageDealt          │
+│  - counterChance            │         │  durationSeconds            │
+│  - shieldCapacity, etc.     │         │  isDraw                     │
+│                             │         │  events: CombatEvent[]      │
+│  + mainWeapon, offhandWeapon│         │                             │
+│  + stance                   │         │                             │
+│  + isTournament flag        │         │                             │
+└─────────────────────────────┘         └─────────────────────────────┘
+```
+
+ELO is NOT used in combat calculations — it's only for matchmaking.
+
+---
+
+## Narrative Generation Pipeline
+
+All three orchestrators convert raw `CombatEvent[]` into human-readable battle narratives using `CombatMessageGenerator`:
+
+```
+  CombatEvent[]                    Narrative Battle Log
+  (raw simulator output)           (stored in Battle.battleLog)
+  ┌──────────────────┐             ┌──────────────────────────────────┐
+  │ timestamp: 2.3   │             │ "⚔️ Thunderstrike lunges with   │
+  │ type: 'attack'   │   ──────►  │  Plasma Blade, dealing 45       │
+  │ damage: 45       │             │  damage to IronClad's shields!" │
+  │ hit: true        │             │                                  │
+  │ critical: false  │             │ "🛡️ IronClad's shields absorb  │
+  │ shieldDamage: 45 │             │  the blow (62% remaining)"      │
+  │ hpDamage: 0      │             └──────────────────────────────────┘
+  └──────────────────┘
+```
+
+### Conversion Methods
+
+| Method | Used by | Purpose |
+|---|---|---|
+| `generateBattleLog()` | All orchestrators | Entry point — delegates to converter or generates minimal log for byes |
+| `convertSimulatorEvents()` | League + Tournament | Converts 1v1 CombatEvent[] to narrative messages |
+| `convertTagTeamEvents()` | Tag Team | Handles phase transitions, tag-outs, reserve activations |
+
+---
+
+## Data Flow: Battle → BattleParticipant → AuditLog
+
+This is the complete write path for a single battle:
+
+```
+  ┌─ Orchestrator ─────────────────────────────────────────────────────┐
+  │                                                                     │
+  │  1. CREATE Battle record                                            │
+  │     ┌──────────────────────────────────────────────┐                │
+  │     │ Battle { id, battleType, winnerId,           │                │
+  │     │   robot1Id, robot2Id, durationSeconds,       │                │
+  │     │   leagueType, cycleNumber, battleLog }       │                │
+  │     └──────────────────────────────────────────────┘                │
+  │                                                                     │
+  │  2. CREATE BattleParticipant records (in same transaction)          │
+  │     ┌─────────────────────────┐  ┌─────────────────────────┐       │
+  │     │ Participant (Robot 1)   │  │ Participant (Robot 2)   │       │
+  │     │ team: 1                 │  │ team: 2                 │       │
+  │     │ role: null (1v1)        │  │ role: null (1v1)        │       │
+  │     │ eloBefore/After         │  │ eloBefore/After         │       │
+  │     │ damageDealt, finalHP    │  │ damageDealt, finalHP    │       │
+  │     │ yielded, destroyed      │  │ yielded, destroyed      │       │
+  │     └─────────────────────────┘  └─────────────────────────┘       │
+  │     (Tag team: 4 records with role = "active" | "reserve")          │
+  │                                                                     │
+  │  3. UPDATE BattleParticipant with economic data                     │
+  │     credits, streamingRevenue, prestigeAwarded, fameAwarded         │
+  │                                                                     │
+  │  4. UPDATE Robot stats                                              │
+  │     currentHP, currentELO, leaguePoints, fame                       │
+  │                                                                     │
+  │  5. UPDATE User stats                                               │
+  │     currency (credits + streaming), prestige                        │
+  │                                                                     │
+  │  6. LOG AuditLog events (one per robot)                             │
+  │     ┌─────────────────────────┐  ┌─────────────────────────┐       │
+  │     │ AuditLog (Robot 1)      │  │ AuditLog (Robot 2)      │       │
+  │     │ eventType: battle_*     │  │ eventType: battle_*     │       │
+  │     │ userId: robot1.userId   │  │ userId: robot2.userId   │       │
+  │     │ robotId: robot1.id      │  │ robotId: robot2.id      │       │
+  │     │ battleId: battle.id     │  │ battleId: battle.id     │       │
+  │     │ payload: {              │  │ payload: {              │       │
+  │     │   credits, elo,         │  │   credits, elo,         │       │
+  │     │   prestige, fame,       │  │   prestige, fame,       │       │
+  │     │   streaming, damage,    │  │   streaming, damage,    │       │
+  │     │   result (win/loss/draw)│  │   result (win/loss/draw)│       │
+  │     │ }                       │  │ }                       │       │
+  │     └─────────────────────────┘  └─────────────────────────┘       │
+  │                                                                     │
+  └─────────────────────────────────────────────────────────────────────┘
+```
+
+### Audit Event Types by Orchestrator
+
+| Orchestrator | Event Type | Events per Battle |
+|---|---|---|
+| League | `battle_complete` | 2 (one per robot) |
+| Tournament | `tournament_match` | 2 (one per robot) |
+| Tag Team | `tag_team_battle` | 4 (one per robot) |
+
+---
+
+## Shared Utilities
+
+The orchestrators share several utility modules:
+
+```
+  ┌─────────────────────────────────────────────────────────────┐
+  │                    SHARED UTILITIES                          │
+  │                                                              │
+  │  battleMath.ts                                               │
+  │    ├─ calculateExpectedScore()    ELO expected outcome       │
+  │    ├─ calculateELOChange()        ELO delta after battle     │
+  │    └─ ELO_K_FACTOR               K-factor constant           │
+  │                                                              │
+  │  economyCalculations.ts                                      │
+  │    ├─ getLeagueBaseReward()       Credits by league tier     │
+  │    ├─ getParticipationReward()    Loser/draw credits         │
+  │    ├─ calculateBattleWinnings()   Total credit calculation   │
+  │    └─ getPrestigeMultiplier()     Prestige bonus %           │
+  │                                                              │
+  │  tournamentRewards.ts                                        │
+  │    ├─ calculateTournamentBattleRewards()                     │
+  │    └─ getTournamentRewardBreakdown()                         │
+  │                                                              │
+  │  streamingRevenueService.ts                                  │
+  │    ├─ calculateStreamingRevenue()       (1v1)                │
+  │    ├─ calculateTagTeamStreamingRevenue() (tag team)          │
+  │    └─ awardStreamingRevenue()           (DB write)           │
+  │                                                              │
+  │  eventLogger.ts                                              │
+  │    └─ EventLogger class (singleton)                          │
+  │       ├─ logEvent()                                          │
+  │       └─ logEventBatch()                                     │
+  └─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## How It All Connects: Scheduling Model
+
+The battle system is driven by `cycleScheduler.ts`, which registers 4 independent cron jobs via `node-cron`. Each job runs on its own schedule, acquires a lock (only one job at a time), and executes its own self-contained cycle. There is no monolithic "8-step cycle" — each job owns its own repair → battle → rebalance → matchmaking flow.
+
+```
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                    DAILY TIMELINE (UTC)                          │
+  │                                                                  │
+  │  08:00    TOURNAMENT CYCLE                                       │
+  │  ├────────────────────────────────────────────────────────┐      │
+  │  │  1. Repair all robots                                  │      │
+  │  │  2. Execute pending tournament matches                 │      │
+  │  │     └─ tournamentBattleOrchestrator                    │      │
+  │  │        .processTournamentBattle()                      │      │
+  │  │     └─ simulateBattle(r1, r2, isTournament=true)       │      │
+  │  │     └─ No draws (HP tiebreaker)                        │      │
+  │  │  3. Advance winners to next round                      │      │
+  │  │  4. Auto-create next tournament if none active         │      │
+  │  └────────────────────────────────────────────────────────┘      │
+  │                                                                  │
+  │  12:00    TAG TEAM CYCLE                                         │
+  │  ├────────────────────────────────────────────────────────┐      │
+  │  │  1. Repair all robots                                  │      │
+  │  │  2. Execute tag team battles (ODD cycles only)         │      │
+  │  │     └─ tagTeamBattleOrchestrator                       │      │
+  │  │        .executeScheduledTagTeamBattles()               │      │
+  │  │     └─ simulateBattle() called per phase               │      │
+  │  │     └─ Tag-out on yield/destruction → reserve tags in  │      │
+  │  │  3. Rebalance tag team leagues                         │      │
+  │  │  4. Matchmaking with 48h lead time                     │      │
+  │  │  (Even cycles: repair only, skip battles)              │      │
+  │  └────────────────────────────────────────────────────────┘      │
+  │                                                                  │
+  │  20:00    LEAGUE CYCLE                                           │
+  │  ├────────────────────────────────────────────────────────┐      │
+  │  │  1. Repair all robots                                  │      │
+  │  │  2. Execute scheduled league battles (1v1)             │      │
+  │  │     └─ battleOrchestrator.executeScheduledBattles()    │      │
+  │  │     └─ simulateBattle(r1, r2, isTournament=false)      │      │
+  │  │     └─ Draws allowed                                   │      │
+  │  │  3. Rebalance leagues (promote/demote)                 │      │
+  │  │  4. Matchmaking with 24h lead time                     │      │
+  │  └────────────────────────────────────────────────────────┘      │
+  │                                                                  │
+  │  23:00    SETTLEMENT (end-of-day economics)                      │
+  │  ├────────────────────────────────────────────────────────┐      │
+  │  │  1. Credit passive income (merchandising hub)          │      │
+  │  │  2. Debit operating costs (facilities + roster)        │      │
+  │  │  3. Log end-of-cycle balances for all users            │      │
+  │  │  4. Increment cycle number (cycleMetadata.totalCycles) │      │
+  │  │  5. Create analytics snapshot (CycleSnapshot)          │      │
+  │  │  6. Auto-generate users (if enabled)                   │      │
+  │  └────────────────────────────────────────────────────────┘      │
+  │                                                                  │
+  │  Locking: acquireLock() ensures only one job runs at a time      │
+  │  Manual:  POST /api/admin/cycles/bulk also available (dev/test)  │
+  └─────────────────────────────────────────────────────────────────┘
+```
+
+### Why 4 Independent Jobs?
+
+The acc/production environment uses individual cron triggers rather than a monolithic cycle. This gives:
+- Independent scheduling per battle type (tournaments morning, leagues evening)
+- Tag team battles on a 48h cadence (odd cycles only) without blocking league play
+- Settlement runs last, after all battles are done, to capture the full day's economic activity
+- Each job repairs robots first, so no battle type depends on another job having run
+- Lock-based mutual exclusion prevents overlapping execution
+
+---
+
+## File Reference
+
+| File | Purpose |
+|---|---|
+| `src/services/cycleScheduler.ts` | 4 independent cron jobs (league, tournament, tag team, settlement) |
+| `src/services/combatSimulator.ts` | Shared combat engine — tick-based simulation using all 23 attributes |
+| `src/services/battleOrchestrator.ts` | League 1v1 battle orchestration, ELO, rewards, audit logging |
+| `src/services/tournamentBattleOrchestrator.ts` | Tournament bracket battles, round-based rewards |
+| `src/services/tagTeamBattleOrchestrator.ts` | 2v2 tag team battles, tag-out mechanics, 4-robot participation |
+| `src/services/combatMessageGenerator.ts` | Raw events → narrative battle log conversion |
+| `src/services/eventLogger.ts` | Audit log writer (one event per robot pattern) |
+| `src/services/streamingRevenueService.ts` | Streaming revenue calculation and awarding |
+| `src/utils/battleMath.ts` | ELO calculations (K-factor, expected score, delta) |
+| `src/utils/economyCalculations.ts` | Credit rewards, prestige multipliers, participation rewards |
+| `src/utils/tournamentRewards.ts` | Tournament-specific reward scaling |
+
+All paths relative to `prototype/backend/`.
+
+---
+
+## Related Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — High-level system architecture and battle simulation engine design
+- [PRD_BATTLE_DATA_ARCHITECTURE.md](PRD_BATTLE_DATA_ARCHITECTURE.md) — BattleParticipant table design and migration
+- [PRD_AUDIT_SYSTEM.md](PRD_AUDIT_SYSTEM.md) — One-event-per-robot audit log architecture
+- [COMBAT_FORMULAS.md](COMBAT_FORMULAS.md) — Detailed combat math (hit chance, damage, crits, counters)
+- [COMBAT_MESSAGES.md](COMBAT_MESSAGES.md) — Narrative generation system and message templates
+- [PRD_TOURNAMENT_SYSTEM.md](PRD_TOURNAMENT_SYSTEM.md) — Tournament bracket system and scheduling
+- [CYCLE_PROCESS.md](../implementation_notes/CYCLE_PROCESS.md) — Legacy 8-step cycle reference (admin bulk API); acc uses cycleScheduler cron jobs instead
+- [PRD_ECONOMY_SYSTEM.md](PRD_ECONOMY_SYSTEM.md) — Credit rewards, streaming revenue, prestige multipliers
+- [PRD_PRESTIGE_AND_FAME.md](PRD_PRESTIGE_AND_FAME.md) — Prestige and fame award calculations

--- a/docs/prd_core/PRD_ECONOMY_SYSTEM.md
+++ b/docs/prd_core/PRD_ECONOMY_SYSTEM.md
@@ -1148,6 +1148,20 @@ final_repair_cost = 32,200 × (1 - 0.60) = ₡12,880
 - Robot cannot participate in next battle until repaired
 - HP does NOT regenerate automatically (must pay repair cost)
 - Energy shields regenerate automatically between battles (no cost)
+- **Manual repairs** via the Repair All button on the `/robots` page receive a **50% discount** on top of all facility discounts, incentivizing active play between cycles
+- **Automatic repairs** during cycle processing pay full price (no manual discount)
+
+**Manual Repair Discount (50%)**:
+
+When players use the "Repair All" button, a 50% discount is applied after all facility discounts:
+
+```
+// Manual repair discount stacking:
+costAfterRepairBay = Math.floor(baseCost × (1 - repairBayDiscount / 100))
+finalManualCost = Math.floor(costAfterRepairBay × 0.5)
+```
+
+The discount is multiplicative. A player with 90% Repair Bay discount pays `Math.floor(baseCost × 0.10 × 0.50)` = 5% of base cost for manual repairs. Automatic repairs during cycle processing are unaffected.
 
 ### 6. Operating Costs (Daily Recurring)
 

--- a/docs/prd_core/PRD_ONBOARDING_SYSTEM.md
+++ b/docs/prd_core/PRD_ONBOARDING_SYSTEM.md
@@ -443,6 +443,13 @@ critical_multiplier = 2.0 - (medical_bay_level × 0.1)
 - Medical Bay Level 1: 1.9× multiplier
 - Medical Bay Level 10: 1.0× (no critical penalty)
 
+**Manual Repair Discount (50%)**:
+- When players use the "Repair All" button on the Robots page, they receive a 50% discount on repair costs
+- This discount stacks with the Repair Bay discount (applied after Repair Bay discount)
+- Automatic repairs during cycle processing pay full price
+- Formula: `finalManualCost = Math.floor(costAfterRepairBay × 0.5)`
+- Incentivizes active play between cycles
+
 **Battle Readiness Requirements**:
 - Robot must have at least one weapon equipped
 - Robot must have HP > 0 (not destroyed)

--- a/docs/prd_core/README.md
+++ b/docs/prd_core/README.md
@@ -23,6 +23,7 @@ Core PRDs define the fundamental game systems, mechanics, and architecture that 
 - `STABLE_SYSTEM.md` - Facility and stable management
 
 ### Combat & Battles
+- `BATTLE_SIMULATION_ARCHITECTURE.md` - How the combat simulator, 3 orchestrators, narrative pipeline, and audit log tie together
 - `COMBAT_FORMULAS.md` - All combat calculation formulas
 - `COMBAT_MESSAGES.md` - Battle message generation system
 - `PRD_BATTLE_STANCES_AND_YIELD.md` - Battle stance mechanics

--- a/docs/prd_pages/PRD_ROBOTS_LIST_PAGE.md
+++ b/docs/prd_pages/PRD_ROBOTS_LIST_PAGE.md
@@ -21,6 +21,7 @@
 - v1.8 (Feb 2, 2026): **CRITICAL FIX** - Repair All button frontend now calculates cost based on actual HP damage, not just repairCost field - works for any robot with HP < maxHP
 - v1.8.1 (Feb 2, 2026): **BACKEND FIX** - Backend repair-all endpoint now matches frontend HP-based cost calculation - end-to-end repair functionality complete
 - v1.9 (Feb 10, 2026): **PRD CLEANUP** - Updated PRD to reflect implementation status, removed outdated sections, added test coverage information, resolved open questions
+- v2.0 (Mar 16, 2026): **MANUAL REPAIR DISCOUNT** - 50% discount on manual repairs via Repair All button, confirmation modal shows discount breakdown (Repair Bay + Manual Repair Discount), updated cost calculation
 
 ---
 
@@ -242,11 +243,15 @@ So that I can quickly prepare my entire fleet for battle
 
 Acceptance Criteria:
 - "Repair All Robots" button displayed in page header
-- Button shows total repair cost for all damaged robots
+- Button shows total repair cost for all damaged robots (after all discounts)
 - Cost includes Repair Bay discount if facility is upgraded
-- Discount percentage displayed (e.g., "₡15,000 (25% off)")
+- Cost includes 50% manual repair discount (applied after Repair Bay discount)
+- Discount percentage displayed (e.g., "₡7,500 (25% + 50% manual off)")
 - Button disabled if no robots need repair or insufficient credits
-- Confirmation modal shows cost breakdown before repair
+- Confirmation modal shows cost breakdown before repair:
+  - Repair Bay Discount: X% off
+  - Manual Repair Discount: 50% off
+  - Final Cost: ₡Y
 - Success message confirms repairs completed
 - Robot HP/Shield bars update after repair
 ```
@@ -311,14 +316,16 @@ Acceptance Criteria:
 - Backend endpoint: POST /api/robots/repair-all
 - Calculate total repair cost for all damaged robots
 - Apply Repair Bay discount (5% per level)
-- Check user has sufficient credits
+- Apply 50% manual repair discount (after Repair Bay discount)
+- Check user has sufficient credits (against discounted cost)
 - Deduct credits from user account
 - Update all robots: currentHP = maxHP, currentShield = maxShield, repairCost = 0
-- Return success message with repair count and costs
-- Frontend shows confirmation dialog before repair
+- Return success message with repair count, costs, and discount breakdown
+- Response includes manualRepairDiscount and preDiscountCost fields
+- Frontend shows confirmation dialog with discount breakdown before repair
 - Frontend shows success message after repair
 - Frontend refreshes robots list to show updated status
-- Handle errors (insufficient credits, etc.)
+- Handle errors (insufficient credits uses discounted cost in error, etc.)
 ```
 
 **US-13: Robot Capacity Indicator** (v1.4)

--- a/prototype/backend/jest.config.unit.js
+++ b/prototype/backend/jest.config.unit.js
@@ -16,6 +16,8 @@ const unitTestFiles = [
   'passwordHashing\\.property\\.test\\.ts',
   'passwordService\\.test\\.ts',
   'recommendationEngine\\.test\\.ts',
+  'manualRepairDiscount\\.property\\.test\\.ts',
+  'manualRepairDiscount\\.test\\.ts',
   'repairCostMultiRobot\\.test\\.ts',
   'storageCalculations\\.test\\.ts',
   'streamingStudioOperatingCost\\.property\\.test\\.ts',

--- a/prototype/backend/src/content/guide/combat/yielding-and-repair-costs.md
+++ b/prototype/backend/src/content/guide/combat/yielding-and-repair-costs.md
@@ -2,7 +2,7 @@
 title: "Yielding & Repair Costs"
 description: "How the yield system works, how it affects repair costs, and the strategic trade-offs between aggressive and conservative surrender settings."
 order: 4
-lastUpdated: "2026-03-11"
+lastUpdated: "2026-03-16"
 relatedArticles:
   - combat/stances
   - combat/battle-flow
@@ -95,10 +95,12 @@ Your [stance choice](/guide/combat/stances) interacts with yield threshold in im
 
 The [Repair Bay](/guide/facilities/repair-bay) facility reduces repair costs through a discount that scales with both the facility level and the number of active robots in your stable. This discount applies *after* the damage and destruction multipliers.
 
-With a well-upgraded Repair Bay and a large roster, even aggressive yield thresholds become more affordable. Players running three robots with a high-level Repair Bay can afford to set lower yield thresholds because the discount cushions the blow.
+On top of the Repair Bay discount, you can save even more by repairing manually. Using the **Repair All** button on the Robots page gives you a **50% manual repair discount** that stacks with the Repair Bay discount. Automatic repairs during the daily cycle don't receive this bonus.
+
+With a well-upgraded Repair Bay, a large roster, and manual repairs, even aggressive yield thresholds become very affordable. Players running three robots with a high-level Repair Bay who repair manually can see their repair costs drop to a fraction of the base price.
 
 ```callout-info
-The Repair Bay discount makes a dramatic difference for multi-robot stables. A player with 7+ robots and a level 5+ Repair Bay can see repair costs drop by more than half, making aggressive play much more economically viable.
+The combination of Repair Bay discount and manual repair discount makes a dramatic difference for multi-robot stables. A player with 7+ robots, a level 5+ Repair Bay, and manual repairs can see repair costs drop far more than half, making aggressive play much more economically viable.
 ```
 
 ## Practical Guidelines
@@ -110,6 +112,7 @@ The Repair Bay discount makes a dramatic difference for multi-robot stables. A p
 | Weak robot, tough league tier | 20–30% | Preserve your budget. Live to fight another day. |
 | Budget is tight, can't afford repairs | 25–40% | Prioritize survival over wins until finances recover. |
 | Robot with high Repair Bay discount | 5–10% | The discount makes aggressive play affordable. |
+| Repairing manually between cycles | 5–15% | The 50% manual repair discount cushions aggressive play. |
 | Climbing the league rankings | 5–15% | You need wins to earn LP. Accept higher repair costs. |
 
 ## Reading Your Results

--- a/prototype/backend/src/content/guide/economy/repair-costs.md
+++ b/prototype/backend/src/content/guide/economy/repair-costs.md
@@ -2,7 +2,7 @@
 title: "Operating Costs & Repairs"
 description: "All the ways Credits flow out of your stable — facility daily costs, repair expenses, and how damage severity and robot attributes influence what you pay."
 order: 3
-lastUpdated: "2026-03-11"
+lastUpdated: "2026-03-16"
 relatedArticles:
   - economy/credits-and-income
   - economy/daily-financial-cycle
@@ -75,9 +75,21 @@ Defensive attributes also play a role:
 Investing in defensive attributes doesn't just help you win battles — it also saves you money on repairs. A well-armored robot that wins with 80% HP remaining costs far less to repair than a glass cannon that wins with 10% HP.
 ```
 
+### Manual Repair Discount
+
+When you manually repair your robots using the **Repair All** button on the Robots page, you receive a **50% discount** on the total repair cost. This discount is applied on top of any Repair Bay savings, so the two stack together for significant savings.
+
+Automatic repairs that happen during the daily cycle do **not** receive this discount — they're charged at the standard rate. This means actively managing your repairs between cycles is one of the most effective ways to save Credits.
+
+```callout-tip
+Always repair your robots manually before the next cycle starts. The 50% manual repair discount can save you thousands of Credits per cycle, especially if you're running multiple robots with heavy battle damage.
+```
+
 ### The Repair Bay Facility
 
 The **Repair Bay** facility reduces repair costs for all your robots. At higher levels, it provides increasingly significant discounts. If you're running multiple robots, the Repair Bay also offers a multi-robot discount that makes it one of the most cost-effective early investments.
+
+Combined with the manual repair discount, a well-upgraded Repair Bay can reduce your repair bills dramatically — making aggressive play much more affordable.
 
 See the [Repair Bay Guide](/guide/facilities/repair-bay) for details on level progression and cost savings.
 
@@ -96,18 +108,21 @@ Track your expenses-to-income ratio. If your total daily expenses are consistent
 - Keep facilities minimal — Training Facility and Repair Bay are usually enough
 - Set yield thresholds conservatively (higher %) to limit repair costs
 - Focus on one or two robots to keep total repair bills manageable
+- **Repair manually** between cycles to take advantage of the 50% manual repair discount
 
 ### Mid Game
 
 - Add income-generating facilities (Merchandising Hub, Streaming Studio) only when your Prestige and Fame justify the operating cost
 - Invest in defensive attributes to reduce per-battle repair costs
 - Consider the Self-Repair Systems attribute for robots that frequently take heavy damage
+- Combine the Repair Bay discount with manual repairs for maximum savings
 
 ### Late Game
 
 - Higher-tier rewards should comfortably cover all operating costs
 - Optimize yield thresholds based on your financial cushion — you can afford to fight more aggressively
 - Facility operating costs become a smaller percentage of total income as battle rewards scale up
+- Even at high income levels, manual repairs still save meaningful Credits over automatic repairs
 
 ## What's Next?
 

--- a/prototype/backend/src/content/guide/getting-started/starting-budget.md
+++ b/prototype/backend/src/content/guide/getting-started/starting-budget.md
@@ -2,7 +2,7 @@
 title: "Your Starting Budget"
 description: "How to spend your initial ₡3,000,000 wisely and set your stable up for long-term success."
 order: 3
-lastUpdated: "2026-03-12"
+lastUpdated: "2026-03-16"
 relatedArticles:
   - getting-started/roster-strategy
   - economy/credits-and-income
@@ -107,6 +107,7 @@ Optional facilities to consider with remaining budget:
 ## Early Game Tips
 
 - **Buy discount facilities before the items they discount** — This is the single most impactful thing you can do with your starting budget.
+- **Repair manually between cycles** — Using the Repair All button gives you a 50% discount on repairs compared to automatic cycle repairs. This adds up fast, especially with multiple robots.
 - **Upgrade attributes in batches** — Focus on 6–8 key attributes rather than spreading thin across all 23.
 - **Watch your cash flow** — After a few cycles, check your Financial Report to make sure income exceeds expenses.
 - **Don't overbuy facilities** — Each facility has daily operating costs. Only buy what you'll actively benefit from right away.

--- a/prototype/backend/src/content/guide/strategy/yield-strategy.md
+++ b/prototype/backend/src/content/guide/strategy/yield-strategy.md
@@ -2,7 +2,7 @@
 title: "Yield Threshold Strategy"
 description: "The strategic implications of yield threshold settings — cost/benefit analysis for aggressive vs conservative approaches and how to optimize for your build."
 order: 2
-lastUpdated: "2026-03-11"
+lastUpdated: "2026-03-16"
 relatedArticles:
   - strategy/build-archetypes
   - getting-started/starting-budget
@@ -72,8 +72,10 @@ The yield threshold directly affects your [repair costs](/guide/economy/repair-c
 | 30% | ~25% HP | ₡5,000–₡10,000 | Comfortable margin |
 | 50% | ~45% HP | ₡2,000–₡5,000 | Very safe |
 
+These estimates assume automatic repairs. If you repair manually using the Repair All button, all of these costs drop by 50% thanks to the [manual repair discount](/guide/economy/repair-costs). That shifts the economics significantly — a 5% yield threshold with manual repairs costs roughly the same as a 30% yield threshold with automatic repairs.
+
 ```callout-tip
-In the early game when your budget is tight, err on the side of higher yield thresholds (35–50%). As your income grows and you can absorb repair costs comfortably, you can lower the threshold to win more fights.
+In the early game when your budget is tight, err on the side of higher yield thresholds (35–50%). As your income grows and you can absorb repair costs comfortably, you can lower the threshold to win more fights. Repairing manually between cycles halves your repair bill regardless of your yield setting.
 ```
 
 ## Adjusting Over Time
@@ -85,6 +87,8 @@ Your optimal yield threshold changes as your stable evolves:
 | Early game | Conservative (35–50%) | Budget is tight, can't afford big repair bills |
 | Mid game | Moderate (20–35%) | Income supports moderate repairs, need wins for promotion |
 | Late game | Aggressive (5–20%) | Income easily covers repairs, every win matters for LP |
+
+If you're repairing manually between cycles, you can afford to be one tier more aggressive than these recommendations suggest, since the 50% manual discount effectively halves your downside risk.
 
 ```callout-tip
 Review your yield threshold every time you promote to a new league tier. Higher tiers mean tougher opponents and more damage taken — you may need to adjust upward temporarily until your robot is competitive at the new level.

--- a/prototype/backend/src/routes/admin.ts
+++ b/prototype/backend/src/routes/admin.ts
@@ -2510,6 +2510,159 @@ router.get('/users/recent', authenticateToken, requireAdmin, async (req: Request
 });
 
 /**
+ * GET /api/admin/audit-log/repairs
+ * Get paginated repair audit log events with optional filtering by repairType and date range.
+ * Returns events, summary stats, and pagination.
+ */
+router.get('/audit-log/repairs', authenticateToken, requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const repairType = req.query.repairType as string | undefined;
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(Math.max(1, parseInt(req.query.limit as string) || 25), 100);
+    const skip = (page - 1) * limit;
+
+    // Validate repairType if provided
+    if (repairType && repairType !== 'manual' && repairType !== 'automatic') {
+      return res.status(400).json({
+        error: "Invalid repairType. Must be 'manual' or 'automatic'",
+      });
+    }
+
+    // Build where clause for audit log query
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = {
+      eventType: 'robot_repair',
+    };
+
+    // Date range filtering
+    if (startDate || endDate) {
+      where.eventTimestamp = {};
+      if (startDate) {
+        where.eventTimestamp.gte = new Date(startDate);
+      }
+      if (endDate) {
+        where.eventTimestamp.lte = new Date(endDate);
+      }
+    }
+
+    // For repairType filtering, we need to filter on the JSON payload field.
+    // Prisma supports JSON filtering with `path` for PostgreSQL.
+    if (repairType) {
+      where.payload = {
+        path: ['repairType'],
+        equals: repairType,
+      };
+    }
+
+    // Get total count for pagination
+    const totalEvents = await prisma.auditLog.count({ where });
+
+    // Fetch paginated audit log events
+    const auditEvents = await prisma.auditLog.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: { eventTimestamp: 'desc' },
+      select: {
+        userId: true,
+        robotId: true,
+        payload: true,
+        eventTimestamp: true,
+      },
+    });
+
+    // Collect unique user and robot IDs for batch lookup
+    const userIds = [...new Set(auditEvents.map(e => e.userId).filter((id): id is number => id !== null))];
+    const robotIds = [...new Set(auditEvents.map(e => e.robotId).filter((id): id is number => id !== null))];
+
+    // Batch fetch users and robots
+    const [users, robots] = await Promise.all([
+      prisma.user.findMany({
+        where: { id: { in: userIds } },
+        select: { id: true, stableName: true, username: true },
+      }),
+      prisma.robot.findMany({
+        where: { id: { in: robotIds } },
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    const userMap = new Map(users.map(u => [u.id, u.stableName || u.username]));
+    const robotMap = new Map(robots.map(r => [r.id, r.name]));
+
+    // Map events to response shape
+    const events = auditEvents.map(event => {
+      const payload = event.payload as Record<string, unknown>;
+      return {
+        userId: event.userId || 0,
+        stableName: userMap.get(event.userId || 0) || 'Unknown',
+        robotId: event.robotId || 0,
+        robotName: robotMap.get(event.robotId || 0) || 'Unknown',
+        repairType: (payload.repairType as 'manual' | 'automatic') || 'automatic',
+        cost: (payload.cost as number) || 0,
+        preDiscountCost: (payload.preDiscountCost as number) ?? null,
+        manualRepairDiscount: (payload.manualRepairDiscount as number) ?? null,
+        eventTimestamp: event.eventTimestamp.toISOString(),
+      };
+    });
+
+    // Calculate summary stats from ALL matching events (not just current page)
+    // We need to fetch all matching events for summary calculation
+    const allEvents = await prisma.auditLog.findMany({
+      where,
+      select: {
+        payload: true,
+      },
+    });
+
+    let totalManualRepairs = 0;
+    let totalAutomaticRepairs = 0;
+    let totalSavings = 0;
+
+    for (const event of allEvents) {
+      const payload = event.payload as Record<string, unknown>;
+      const eventRepairType = (payload.repairType as string) || 'automatic';
+      if (eventRepairType === 'manual') {
+        totalManualRepairs++;
+        const preDiscount = payload.preDiscountCost as number | undefined;
+        const cost = payload.cost as number | undefined;
+        if (preDiscount != null && cost != null) {
+          totalSavings += preDiscount - cost;
+        }
+      } else {
+        totalAutomaticRepairs++;
+      }
+    }
+
+    const totalPages = Math.ceil(totalEvents / limit);
+
+    res.json({
+      events,
+      summary: {
+        totalManualRepairs,
+        totalAutomaticRepairs,
+        totalSavings,
+      },
+      pagination: {
+        page,
+        limit,
+        totalEvents,
+        totalPages,
+        hasMore: page < totalPages,
+      },
+    });
+  } catch (error) {
+    logger.error('[Admin] Repair audit log error:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve repair audit log',
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+/**
  * GET /api/admin/scheduler/status
  * Return the current state of the Cycle Scheduler
  */

--- a/prototype/backend/src/routes/robots.ts
+++ b/prototype/backend/src/routes/robots.ts
@@ -1149,8 +1149,10 @@ router.post('/repair-all', authenticateToken, async (req: AuthRequest, res: Resp
     }
 
     // Calculate total cost
+    const MANUAL_REPAIR_DISCOUNT = 0.5;
     const totalBaseCost = robotsNeedingRepair.reduce((sum, robot) => sum + robot.calculatedRepairCost, 0);
-    const finalCost = Math.floor(totalBaseCost * (1 - discount / 100));
+    const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100));
+    const finalCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
 
     // Check if user has enough credits
     if (user.currency < finalCost) {
@@ -1187,11 +1189,38 @@ router.post('/repair-all', authenticateToken, async (req: AuthRequest, res: Resp
       return { user: updatedUser, robots: updatedRobots };
     });
 
+    // Log repair events for each repaired robot
+    try {
+      for (const robot of robotsNeedingRepair) {
+        const perRobotBaseCost = robot.calculatedRepairCost;
+        const perRobotCostAfterRepairBay = Math.floor(perRobotBaseCost * (1 - discount / 100));
+        const perRobotFinalCost = Math.floor(perRobotCostAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
+        const damageRepaired = robot.maxHP - robot.currentHP;
+
+        await eventLogger.logRobotRepair(
+          userId,
+          robot.id,
+          perRobotFinalCost,
+          damageRepaired,
+          discount,
+          undefined,
+          'manual',
+          50,
+          perRobotCostAfterRepairBay
+        );
+      }
+    } catch (logError) {
+      logger.error('Failed to log manual repair events:', logError);
+      // Don't fail the request if logging fails
+    }
+
     res.json({
       success: true,
       repairedCount: robotsNeedingRepair.length,
       totalBaseCost,
       discount,
+      manualRepairDiscount: 50,
+      preDiscountCost: costAfterRepairBay,
       finalCost,
       newCurrency: result.user.currency,
       message: `Successfully repaired ${robotsNeedingRepair.length} robot(s) for ₡${finalCost.toLocaleString()}`,

--- a/prototype/backend/src/services/eventLogger.ts
+++ b/prototype/backend/src/services/eventLogger.ts
@@ -540,7 +540,10 @@ export class EventLogger {
     cost: number,
     damageRepaired: number,
     discountPercent: number,
-    cycleNumber?: number
+    cycleNumber?: number,
+    repairType?: 'manual' | 'automatic',
+    manualRepairDiscount?: number,
+    preDiscountCost?: number
   ): Promise<void> {
     // Use provided cycle number, or get current cycle number from metadata
     let actualCycleNumber = cycleNumber;
@@ -551,14 +554,26 @@ export class EventLogger {
       actualCycleNumber = cycleMetadata?.totalCycles || 0;
     }
     
+    const payload: BaseEventPayload = {
+      cost,
+      damageRepaired,
+      discountPercent,
+    };
+
+    if (repairType !== undefined) {
+      payload.repairType = repairType;
+    }
+    if (manualRepairDiscount !== undefined) {
+      payload.manualRepairDiscount = manualRepairDiscount;
+    }
+    if (preDiscountCost !== undefined) {
+      payload.preDiscountCost = preDiscountCost;
+    }
+
     await this.logEvent(
       actualCycleNumber,
       EventType.ROBOT_REPAIR,
-      {
-        cost,
-        damageRepaired,
-        discountPercent,
-      },
+      payload,
       { userId, robotId }
     );
   }

--- a/prototype/backend/src/services/repairService.ts
+++ b/prototype/backend/src/services/repairService.ts
@@ -151,7 +151,8 @@ export async function repairAllRobots(deductCosts: boolean = true, cycleNumber?:
           repairCost,
           damageTaken,
           repairBayDiscount,
-          cycleNumber
+          cycleNumber,
+          'automatic'
         );
         
         // Get user's stable name for logging

--- a/prototype/backend/tests/adminRepairAuditLog.test.ts
+++ b/prototype/backend/tests/adminRepairAuditLog.test.ts
@@ -1,0 +1,334 @@
+import request from 'supertest';
+import prisma from '../src/lib/prisma';
+import bcrypt from 'bcrypt';
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import adminRoutes from '../src/routes/admin';
+import authRoutes from '../src/routes/auth';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use('/api/admin', adminRoutes);
+app.use('/api/auth', authRoutes);
+
+describe('GET /api/admin/audit-log/repairs', () => {
+  let adminToken: string;
+  let testUserId: number;
+  let testRobotId: number;
+  const testUserIds: number[] = [];
+  const testAuditLogIds: bigint[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+
+    // Create admin user
+    const adminUsername = `admin_repair_audit_${Date.now()}`;
+    const adminPassword = 'adminpass123';
+    const passwordHash = await bcrypt.hash(adminPassword, 10);
+
+    const adminUser = await prisma.user.create({
+      data: {
+        username: adminUsername,
+        stableName: `TestStable_${Date.now()}`,
+        passwordHash,
+        role: 'admin',
+        currency: 1000000,
+      },
+    });
+    testUserId = adminUser.id;
+    testUserIds.push(adminUser.id);
+
+    // Login to get admin token
+    const loginResponse = await request(app)
+      .post('/api/auth/login')
+      .send({ username: adminUsername, password: adminPassword });
+    adminToken = loginResponse.body.token;
+
+    // Create a test robot
+    const robot = await prisma.robot.create({
+      data: {
+        userId: testUserId,
+        name: `RepairAuditBot_${Date.now()}`,
+        currentHP: 100,
+        maxHP: 100,
+        currentShield: 0,
+        maxShield: 0,
+      },
+    });
+    testRobotId = robot.id;
+
+    // Get a unique cycle number for test data
+    const cycleMetadata = await prisma.cycleMetadata.findUnique({ where: { id: 1 } });
+    const testCycleNumber = (cycleMetadata?.totalCycles || 0) + 9000; // Use high number to avoid conflicts
+
+    // Create test audit log entries
+    const now = new Date();
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+    const manualEntry1 = await prisma.auditLog.create({
+      data: {
+        cycleNumber: testCycleNumber,
+        eventType: 'robot_repair',
+        sequenceNumber: 1,
+        userId: testUserId,
+        robotId: testRobotId,
+        eventTimestamp: now,
+        payload: {
+          cost: 2500,
+          damageRepaired: 50,
+          discountPercent: 14,
+          repairType: 'manual',
+          manualRepairDiscount: 50,
+          preDiscountCost: 5000,
+        },
+      },
+    });
+    testAuditLogIds.push(manualEntry1.id);
+
+    const manualEntry2 = await prisma.auditLog.create({
+      data: {
+        cycleNumber: testCycleNumber,
+        eventType: 'robot_repair',
+        sequenceNumber: 2,
+        userId: testUserId,
+        robotId: testRobotId,
+        eventTimestamp: oneDayAgo,
+        payload: {
+          cost: 1000,
+          damageRepaired: 30,
+          discountPercent: 0,
+          repairType: 'manual',
+          manualRepairDiscount: 50,
+          preDiscountCost: 2000,
+        },
+      },
+    });
+    testAuditLogIds.push(manualEntry2.id);
+
+    const automaticEntry = await prisma.auditLog.create({
+      data: {
+        cycleNumber: testCycleNumber,
+        eventType: 'robot_repair',
+        sequenceNumber: 3,
+        userId: testUserId,
+        robotId: testRobotId,
+        eventTimestamp: twoDaysAgo,
+        payload: {
+          cost: 5000,
+          damageRepaired: 50,
+          discountPercent: 14,
+          repairType: 'automatic',
+        },
+      },
+    });
+    testAuditLogIds.push(automaticEntry.id);
+  });
+
+  afterAll(async () => {
+    // Cleanup audit log entries
+    if (testAuditLogIds.length > 0) {
+      await prisma.auditLog.deleteMany({
+        where: { id: { in: testAuditLogIds } },
+      });
+    }
+
+    // Cleanup robot
+    if (testRobotId) {
+      await prisma.robot.deleteMany({ where: { id: testRobotId } });
+    }
+
+    // Cleanup users
+    if (testUserIds.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: testUserIds } } });
+    }
+
+    await prisma.$disconnect();
+  });
+
+  it('should require authentication', async () => {
+    const response = await request(app).get('/api/admin/audit-log/repairs');
+    expect(response.status).toBe(401);
+  });
+
+  it('should require admin role', async () => {
+    const regularUsername = `user_repair_audit_${Date.now()}`;
+    const regularPassword = 'userpass123';
+    const passwordHash = await bcrypt.hash(regularPassword, 10);
+
+    const regularUser = await prisma.user.create({
+      data: { username: regularUsername, passwordHash, role: 'user' },
+    });
+    testUserIds.push(regularUser.id);
+
+    const loginResponse = await request(app)
+      .post('/api/auth/login')
+      .send({ username: regularUsername, password: regularPassword });
+
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${loginResponse.body.token}`);
+
+    expect(response.status).toBe(403);
+  });
+
+  it('should return repair events with correct response shape', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('events');
+    expect(response.body).toHaveProperty('summary');
+    expect(response.body).toHaveProperty('pagination');
+
+    // Check summary shape
+    expect(response.body.summary).toHaveProperty('totalManualRepairs');
+    expect(response.body.summary).toHaveProperty('totalAutomaticRepairs');
+    expect(response.body.summary).toHaveProperty('totalSavings');
+
+    // Check pagination shape
+    expect(response.body.pagination).toHaveProperty('page');
+    expect(response.body.pagination).toHaveProperty('limit');
+    expect(response.body.pagination).toHaveProperty('totalEvents');
+    expect(response.body.pagination).toHaveProperty('totalPages');
+    expect(response.body.pagination).toHaveProperty('hasMore');
+  });
+
+  it('should return events with correct event shape', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.events.length).toBeGreaterThan(0);
+
+    const event = response.body.events[0];
+    expect(event).toHaveProperty('userId');
+    expect(event).toHaveProperty('stableName');
+    expect(event).toHaveProperty('robotId');
+    expect(event).toHaveProperty('robotName');
+    expect(event).toHaveProperty('repairType');
+    expect(event).toHaveProperty('cost');
+    expect(event).toHaveProperty('preDiscountCost');
+    expect(event).toHaveProperty('manualRepairDiscount');
+    expect(event).toHaveProperty('eventTimestamp');
+  });
+
+  it('should filter by repairType=manual', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs?repairType=manual')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    for (const event of response.body.events) {
+      expect(event.repairType).toBe('manual');
+    }
+  });
+
+  it('should filter by repairType=automatic', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs?repairType=automatic')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    for (const event of response.body.events) {
+      expect(event.repairType).toBe('automatic');
+    }
+  });
+
+  it('should return 400 for invalid repairType', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs?repairType=invalid')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Invalid repairType');
+  });
+
+  it('should default page to 1 and limit to 25', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.pagination.page).toBe(1);
+    expect(response.body.pagination.limit).toBe(25);
+  });
+
+  it('should respect custom page and limit params', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs?page=1&limit=2')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.pagination.limit).toBe(2);
+    expect(response.body.events.length).toBeLessThanOrEqual(2);
+  });
+
+  it('should calculate summary stats correctly', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    const { summary } = response.body;
+
+    // We created 2 manual + 1 automatic entries (at minimum)
+    expect(summary.totalManualRepairs).toBeGreaterThanOrEqual(2);
+    expect(summary.totalAutomaticRepairs).toBeGreaterThanOrEqual(1);
+    // Savings = (5000 - 2500) + (2000 - 1000) = 3500 (at minimum from our test data)
+    expect(summary.totalSavings).toBeGreaterThanOrEqual(3500);
+  });
+
+  it('should filter by date range', async () => {
+    const now = new Date();
+    const startDate = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString(); // 12 hours ago
+
+    const response = await request(app)
+      .get(`/api/admin/audit-log/repairs?startDate=${startDate}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    // Should include the most recent entry but potentially exclude older ones
+    for (const event of response.body.events) {
+      expect(new Date(event.eventTimestamp).getTime()).toBeGreaterThanOrEqual(new Date(startDate).getTime());
+    }
+  });
+
+  it('should include stableName and robotName from joined tables', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+
+    // Find an event from our test user
+    const testEvent = response.body.events.find(
+      (e: { userId: number }) => e.userId === testUserId
+    );
+
+    if (testEvent) {
+      expect(testEvent.stableName).toBeTruthy();
+      expect(testEvent.stableName).not.toBe('Unknown');
+      expect(testEvent.robotName).toBeTruthy();
+      expect(testEvent.robotName).not.toBe('Unknown');
+    }
+  });
+
+  it('should return null for preDiscountCost and manualRepairDiscount on automatic repairs', async () => {
+    const response = await request(app)
+      .get('/api/admin/audit-log/repairs?repairType=automatic')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    for (const event of response.body.events) {
+      expect(event.preDiscountCost).toBeNull();
+      expect(event.manualRepairDiscount).toBeNull();
+    }
+  });
+});

--- a/prototype/backend/tests/manualRepairDiscount.property.test.ts
+++ b/prototype/backend/tests/manualRepairDiscount.property.test.ts
@@ -1,0 +1,294 @@
+import * as fc from 'fast-check';
+import { calculateRepairCost } from '../src/utils/robotCalculations';
+
+// Feature: manual-repair-cost-reduction, Property 1: Manual discount formula
+
+/**
+ * Pure manual repair discount formula — mirrors the calculation in
+ * POST /api/robots/repair-all (robots.ts).
+ *
+ * costAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100))
+ * finalCost          = Math.floor(costAfterRepairBay * 0.5)
+ */
+function calculateManualRepairCost(baseCost: number, repairBayDiscount: number): number {
+  const costAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+  const finalCost = Math.floor(costAfterRepairBay * 0.5);
+  return finalCost;
+}
+
+// Feature: manual-repair-cost-reduction, Property 3: Currency validation uses discounted cost
+
+/**
+ * Simulates the currency validation logic for manual repairs.
+ *
+ * Given a player's currency, a base repair cost, and a Repair Bay discount
+ * percentage, calculates the discounted cost (after Repair Bay + 50% manual
+ * discount) and determines whether the repair is allowed.
+ *
+ * - If playerCurrency >= discountedCost → { allowed: true, cost: discountedCost }
+ * - If playerCurrency < discountedCost  → { allowed: false, required: discountedCost, current: playerCurrency }
+ */
+function validateCurrencyForRepair(
+  playerCurrency: number,
+  baseCost: number,
+  repairBayDiscount: number
+): { allowed: true; cost: number } | { allowed: false; required: number; current: number } {
+  const costAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+  const discountedCost = Math.floor(costAfterRepairBay * 0.5);
+
+  if (playerCurrency >= discountedCost) {
+    return { allowed: true, cost: discountedCost };
+  }
+  return { allowed: false, required: discountedCost, current: playerCurrency };
+}
+
+// Feature: manual-repair-cost-reduction, Property 6: Repair type correctly tagged
+
+/**
+ * Simulates the repair type tagging logic for audit log payloads.
+ *
+ * - Manual repairs (POST /api/robots/repair-all) produce a payload with
+ *   repairType: 'manual', manualRepairDiscount: 50, and preDiscountCost.
+ * - Automatic repairs (repairAllRobots() during cycle processing) produce a
+ *   payload with repairType: 'automatic' and no manual-specific fields.
+ */
+function buildRepairAuditPayload(
+  repairSource: 'manual' | 'automatic',
+  cost: number,
+  preDiscountCost: number
+): Record<string, unknown> {
+  if (repairSource === 'manual') {
+    return {
+      repairType: 'manual',
+      manualRepairDiscount: 50,
+      preDiscountCost,
+      cost,
+    };
+  }
+  return {
+    repairType: 'automatic',
+    cost,
+  };
+}
+
+describe('Manual Repair Discount - Property Tests', () => {
+  describe('Property 1: Manual discount formula', () => {
+    /**
+     * **Validates: Requirements 1.1, 1.2, 1.3, 3.1**
+     *
+     * For any valid base cost (non-negative integer) and any Repair Bay discount
+     * percentage (0–90), the manual repair final cost shall equal
+     * Math.floor(Math.floor(baseCost * (1 - repairBayDiscount / 100)) * 0.5).
+     */
+    test('manual cost equals Math.floor(Math.floor(baseCost * (1 - repairBayDiscount / 100)) * 0.5)', () => {
+      fc.assert(
+        fc.property(
+          fc.nat(1_000_000),                      // baseCost
+          fc.integer({ min: 0, max: 90 }),        // repairBayDiscount
+          (baseCost, repairBayDiscount) => {
+            const result = calculateManualRepairCost(baseCost, repairBayDiscount);
+
+            const expectedCostAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+            const expectedFinalCost = Math.floor(expectedCostAfterRepairBay * 0.5);
+
+            expect(result).toBe(expectedFinalCost);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  // Feature: manual-repair-cost-reduction, Property 2: Automatic repair cost unchanged
+  describe('Property 2: Automatic repair cost unchanged', () => {
+    /**
+     * **Validates: Requirements 2.1, 2.2, 2.3**
+     *
+     * For any valid inputs, calculateRepairCost() output is identical with no
+     * manual discount applied — i.e., the function itself has no 0.5 multiplier.
+     * The result is a non-negative number equal to the expected formula:
+     *   baseRepairCost = sumOfAllAttributes * 100
+     *   multiplier = 2.0 (with Medical Bay reduction) if hpPercent === 0,
+     *                1.5 if hpPercent < 10, else 1.0
+     *   rawCost = baseRepairCost * (damagePercent / 100) * multiplier
+     *   repairBayDiscount = min(repairBayLevel * (5 + robotCount), 90) / 100
+     *   finalCost = Math.round(rawCost * (1 - repairBayDiscount))
+     */
+    test('calculateRepairCost() returns expected formula result with no 0.5 multiplier', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 500 }),       // attributeSum
+          fc.float({ min: 0, max: 100 }),          // damagePercent
+          fc.float({ min: 0, max: 100 }),          // hpPercent
+          fc.integer({ min: 0, max: 10 }),         // repairBayLevel
+          fc.integer({ min: 0, max: 10 }),         // medicalBayLevel
+          fc.integer({ min: 1, max: 20 }),         // robotCount
+          (attributeSum, damagePercent, hpPercent, repairBayLevel, medicalBayLevel, robotCount) => {
+            // Skip NaN-producing floats
+            if (!Number.isFinite(damagePercent) || !Number.isFinite(hpPercent)) return;
+
+            const result = calculateRepairCost(
+              attributeSum,
+              damagePercent,
+              hpPercent,
+              repairBayLevel,
+              medicalBayLevel,
+              robotCount
+            );
+
+            // Result must be non-negative
+            expect(result).toBeGreaterThanOrEqual(0);
+
+            // Recompute expected value using the same formula (no 0.5 multiplier)
+            const baseRepairCost = attributeSum * 100;
+
+            let multiplier = 1.0;
+            if (hpPercent === 0) {
+              if (medicalBayLevel > 0) {
+                const medicalReduction = medicalBayLevel * 0.1;
+                multiplier = 2.0 * (1 - medicalReduction);
+              } else {
+                multiplier = 2.0;
+              }
+            } else if (hpPercent < 10) {
+              multiplier = 1.5;
+            }
+
+            const rawCost = baseRepairCost * (damagePercent / 100) * multiplier;
+
+            const rawDiscount = repairBayLevel * (5 + robotCount);
+            const repairBayDiscount = Math.min(rawDiscount, 90) / 100;
+            const expectedCost = Math.round(rawCost * (1 - repairBayDiscount));
+
+            expect(result).toBe(expectedCost);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  // Feature: manual-repair-cost-reduction, Property 3: Currency validation uses discounted cost
+  describe('Property 3: Currency validation uses discounted cost', () => {
+    /**
+     * **Validates: Requirements 4.1, 4.2**
+     *
+     * For any player currency value, base cost, and Repair Bay discount (0–90),
+     * the repair is allowed iff playerCurrency >= discountedCost (after 50% manual
+     * discount). When rejected, the error's `required` field equals the discounted cost.
+     */
+    test('repair allowed iff currency >= discounted cost; rejected error required equals discounted cost', () => {
+      fc.assert(
+        fc.property(
+          fc.nat(10_000_000),                     // playerCurrency
+          fc.nat(1_000_000),                      // baseCost
+          fc.integer({ min: 0, max: 90 }),        // repairBayDiscount
+          (playerCurrency, baseCost, repairBayDiscount) => {
+            const result = validateCurrencyForRepair(playerCurrency, baseCost, repairBayDiscount);
+
+            const costAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+            const discountedCost = Math.floor(costAfterRepairBay * 0.5);
+
+            if (playerCurrency >= discountedCost) {
+              expect(result.allowed).toBe(true);
+              expect((result as { allowed: true; cost: number }).cost).toBe(discountedCost);
+            } else {
+              expect(result.allowed).toBe(false);
+              const rejected = result as { allowed: false; required: number; current: number };
+              expect(rejected.required).toBe(discountedCost);
+              expect(rejected.current).toBe(playerCurrency);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  // Feature: manual-repair-cost-reduction, Property 4: Manual cost ≤ automatic cost
+  describe('Property 4: Manual cost ≤ automatic cost', () => {
+    /**
+     * **Validates: Requirements 1.1, 6.5**
+     *
+     * For any valid base cost (non-negative integer) and any Repair Bay discount
+     * percentage (0–90), the manual repair cost shall be less than or equal to
+     * the automatic repair cost (costAfterRepairBay, before the 50% manual discount).
+     */
+    test('manual cost is at most the automatic cost (costAfterRepairBay)', () => {
+      fc.assert(
+        fc.property(
+          fc.nat(1_000_000),                      // baseCost
+          fc.integer({ min: 0, max: 90 }),        // repairBayDiscount
+          (baseCost, repairBayDiscount) => {
+            const manualCost = calculateManualRepairCost(baseCost, repairBayDiscount);
+            const automaticCost = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+
+            expect(manualCost).toBeLessThanOrEqual(automaticCost);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  // Feature: manual-repair-cost-reduction, Property 5: Manual cost non-negative
+  describe('Property 5: Manual cost non-negative', () => {
+    /**
+     * **Validates: Requirements 1.1, 6.6**
+     *
+     * For any valid base cost (non-negative integer) and any Repair Bay discount
+     * percentage (0–90), the manual repair cost shall be greater than or equal to zero.
+     */
+    test('manual cost is non-negative for any valid inputs', () => {
+      fc.assert(
+        fc.property(
+          fc.nat(1_000_000),                      // baseCost
+          fc.integer({ min: 0, max: 90 }),        // repairBayDiscount
+          (baseCost, repairBayDiscount) => {
+            const manualCost = calculateManualRepairCost(baseCost, repairBayDiscount);
+
+            expect(manualCost).toBeGreaterThanOrEqual(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  // Feature: manual-repair-cost-reduction, Property 6: Repair type correctly tagged
+  describe('Property 6: Repair type correctly tagged', () => {
+    /**
+     * **Validates: Requirements 7.1, 7.2**
+     *
+     * For any repair event, if the repair source is 'manual' then the audit log
+     * payload's repairType field shall be "manual" with manualRepairDiscount and
+     * preDiscountCost present. If the repair source is 'automatic' then the
+     * repairType field shall be "automatic" with no manual-specific fields.
+     */
+    test('manual source produces repairType "manual" with discount fields; automatic produces repairType "automatic" without them', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom('manual' as const, 'automatic' as const),
+          fc.nat(1_000_000),                      // cost
+          fc.nat(1_000_000),                      // preDiscountCost
+          (repairSource, cost, preDiscountCost) => {
+            const payload = buildRepairAuditPayload(repairSource, cost, preDiscountCost);
+
+            expect(payload.repairType).toBe(repairSource);
+
+            if (repairSource === 'manual') {
+              expect(payload.repairType).toBe('manual');
+              expect(payload.manualRepairDiscount).toBe(50);
+              expect(payload.preDiscountCost).toBe(preDiscountCost);
+            } else {
+              expect(payload.repairType).toBe('automatic');
+              expect(payload).not.toHaveProperty('manualRepairDiscount');
+              expect(payload).not.toHaveProperty('preDiscountCost');
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/prototype/backend/tests/manualRepairDiscount.test.ts
+++ b/prototype/backend/tests/manualRepairDiscount.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Manual Repair Discount — Unit Tests
+ *
+ * Tests the pure discount calculation logic used by
+ * POST /api/robots/repair-all. No database or HTTP layer involved.
+ *
+ * Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 4.1, 4.2, 6.1, 6.2, 6.3, 6.7
+ */
+
+import { calculateRepairCost } from '../src/utils/robotCalculations';
+
+/** Mirrors the calculation in the repair-all endpoint */
+function calculateManualRepairCost(baseCost: number, repairBayDiscount: number) {
+  const costAfterRepairBay = Math.floor(baseCost * (1 - repairBayDiscount / 100));
+  const finalCost = Math.floor(costAfterRepairBay * 0.5);
+  return { costAfterRepairBay, finalCost };
+}
+
+/** Simulates the response shape returned by the endpoint */
+function buildRepairResponse(
+  totalBaseCost: number,
+  repairBayDiscount: number,
+  repairedCount: number,
+  playerCurrency: number,
+) {
+  const { costAfterRepairBay, finalCost } = calculateManualRepairCost(totalBaseCost, repairBayDiscount);
+
+  if (playerCurrency < finalCost) {
+    return {
+      error: 'Insufficient credits',
+      required: finalCost,
+      current: playerCurrency,
+    };
+  }
+
+  return {
+    success: true,
+    repairedCount,
+    totalBaseCost,
+    discount: repairBayDiscount,
+    manualRepairDiscount: 50,
+    preDiscountCost: costAfterRepairBay,
+    finalCost,
+    newCurrency: playerCurrency - finalCost,
+    message: `Repaired ${repairedCount} robots`,
+  };
+}
+
+describe('Manual Repair Discount — Unit Tests', () => {
+  describe('50% discount calculation', () => {
+    // Validates: Requirement 1.1
+    it('should apply 50% discount on known cost (base 10000, no Repair Bay → 5000)', () => {
+      const { finalCost } = calculateManualRepairCost(10000, 0);
+      expect(finalCost).toBe(5000);
+    });
+
+    // Validates: Requirement 6.2
+    it('should round down odd cost (base 10001 → Math.floor(10001 * 0.5) = 5000)', () => {
+      const { finalCost } = calculateManualRepairCost(10001, 0);
+      expect(finalCost).toBe(5000);
+    });
+
+    // Validates: Requirements 1.2, 6.7
+    // Note: Math.floor(100000 * 0.1) = 9999 due to floating-point (0.1 ≈ 0.09999...)
+    it('should stack Repair Bay 90% + manual 50% (base 100000 → 9999 → 4999)', () => {
+      const { costAfterRepairBay, finalCost } = calculateManualRepairCost(100000, 90);
+      const expectedAfterRepairBay = Math.floor(100000 * (1 - 90 / 100));
+      expect(costAfterRepairBay).toBe(expectedAfterRepairBay); // 9999
+      expect(finalCost).toBe(Math.floor(expectedAfterRepairBay * 0.5)); // 4999
+    });
+
+    // Validates: Requirement 1.3
+    it('should apply 50% manual discount when Repair Bay is 0%', () => {
+      const { costAfterRepairBay, finalCost } = calculateManualRepairCost(20000, 0);
+      expect(costAfterRepairBay).toBe(20000);
+      expect(finalCost).toBe(10000);
+    });
+
+    it('should return zero cost when base cost is zero (zero damage)', () => {
+      const { finalCost } = calculateManualRepairCost(0, 0);
+      expect(finalCost).toBe(0);
+    });
+  });
+
+  describe('Response shape', () => {
+    // Validates: Requirement 1.4
+    it('should contain manualRepairDiscount field set to 50', () => {
+      const response = buildRepairResponse(10000, 0, 2, 100000);
+      expect(response).toHaveProperty('manualRepairDiscount', 50);
+    });
+
+    // Validates: Requirement 5.2
+    it('should contain preDiscountCost field', () => {
+      const response = buildRepairResponse(10000, 0, 2, 100000);
+      expect(response).toHaveProperty('preDiscountCost', 10000);
+    });
+
+    it('should contain finalCost reflecting the 50% discount', () => {
+      const response = buildRepairResponse(10000, 0, 2, 100000);
+      expect(response).toHaveProperty('finalCost', 5000);
+    });
+  });
+
+  describe('Insufficient credits with discounted cost', () => {
+    // Validates: Requirements 4.1, 4.2
+    it('should return error with discounted required amount when credits are insufficient', () => {
+      // Base 10000, no Repair Bay → discounted cost = 5000
+      // Player has 3000 credits — less than 5000
+      const response = buildRepairResponse(10000, 0, 2, 3000);
+      expect(response).toEqual({
+        error: 'Insufficient credits',
+        required: 5000,
+        current: 3000,
+      });
+    });
+
+    it('should allow repair when credits exactly equal discounted cost', () => {
+      const response = buildRepairResponse(10000, 0, 1, 5000);
+      expect(response).toHaveProperty('success', true);
+      expect(response).toHaveProperty('newCurrency', 0);
+    });
+
+    it('should use discounted cost (not pre-discount) for the required field', () => {
+      // Base 100000, Repair Bay 90% → pre-discount 9999 (floating-point), discounted 4999
+      // Player has 4998 credits — less than 4999
+      const response = buildRepairResponse(100000, 90, 3, 4998);
+      expect(response).toEqual({
+        error: 'Insufficient credits',
+        required: 4999,
+        current: 4998,
+      });
+    });
+  });
+
+  // Validates: Requirements 2.1, 2.2, 2.3, 6.3
+  describe('Regression: calculateRepairCost() unchanged for known inputs', () => {
+    it('should return 5000 for attributeSum=100, damagePercent=50, hpPercent=50, repairBayLevel=0, medicalBayLevel=0, robotCount=5', () => {
+      // baseRepairCost = 100 * 100 = 10000
+      // hpPercent=50 → multiplier = 1.0
+      // rawCost = 10000 * 0.5 * 1.0 = 5000
+      // rawDiscount = 0 * (5 + 5) = 0, repairBayDiscount = 0
+      // finalCost = Math.round(5000 * 1) = 5000
+      const result = calculateRepairCost(100, 50, 50, 0, 0, 5);
+      expect(result).toBe(5000);
+    });
+
+    it('should return 7000 for attributeSum=200, damagePercent=100, hpPercent=0, repairBayLevel=5, medicalBayLevel=3, robotCount=10', () => {
+      // baseRepairCost = 200 * 100 = 20000
+      // hpPercent=0, medicalBayLevel=3 → medicalReduction = 0.3, multiplier = 2.0 * 0.7 = 1.4
+      // rawCost = 20000 * 1.0 * 1.4 = 28000
+      // rawDiscount = 5 * (5 + 10) = 75, repairBayDiscount = 0.75
+      // finalCost = Math.round(28000 * 0.25) = 7000
+      const result = calculateRepairCost(200, 100, 0, 5, 3, 10);
+      expect(result).toBe(7000);
+    });
+  });
+
+  // Validates: Requirements 2.1, 2.2, 2.3, 6.3
+  describe('Regression: automatic repair audit payload excludes manual discount fields', () => {
+    /**
+     * Simulates the audit payload construction for the automatic repair path
+     * in repairService.ts → eventLogger.logRobotRepair().
+     *
+     * The automatic path passes repairType: 'automatic' but does NOT pass
+     * manualRepairDiscount or preDiscountCost, so those fields must be absent.
+     */
+    function buildAutomaticRepairAuditPayload(
+      cost: number,
+      damageRepaired: number,
+      discountPercent: number,
+    ): Record<string, unknown> {
+      const payload: Record<string, unknown> = {
+        cost,
+        damageRepaired,
+        discountPercent,
+        repairType: 'automatic',
+      };
+      // Automatic path does NOT set manualRepairDiscount or preDiscountCost
+      return payload;
+    }
+
+    it('should not include manualRepairDiscount in automatic repair audit payload', () => {
+      const payload = buildAutomaticRepairAuditPayload(5000, 150, 14);
+      expect(payload).not.toHaveProperty('manualRepairDiscount');
+    });
+
+    it('should not include preDiscountCost in automatic repair audit payload', () => {
+      const payload = buildAutomaticRepairAuditPayload(5000, 150, 14);
+      expect(payload).not.toHaveProperty('preDiscountCost');
+    });
+
+    it('should set repairType to "automatic" in audit payload', () => {
+      const payload = buildAutomaticRepairAuditPayload(7000, 200, 75);
+      expect(payload.repairType).toBe('automatic');
+    });
+
+    it('should include cost, damageRepaired, and discountPercent in audit payload', () => {
+      const payload = buildAutomaticRepairAuditPayload(7000, 200, 75);
+      expect(payload).toEqual({
+        cost: 7000,
+        damageRepaired: 200,
+        discountPercent: 75,
+        repairType: 'automatic',
+      });
+    });
+  });
+});

--- a/prototype/frontend/src/components/admin/RepairLogTab.tsx
+++ b/prototype/frontend/src/components/admin/RepairLogTab.tsx
@@ -1,0 +1,290 @@
+/**
+ * RepairLogTab - Admin tab for viewing manual vs automatic repair activity.
+ *
+ * Fetches from GET /api/admin/audit-log/repairs with filters for repair type
+ * and date range. Shows summary stats, filterable data table, and pagination.
+ *
+ * Requirements: 7.4, 7.5, 7.6
+ */
+import { useState, useEffect, useCallback } from 'react';
+import apiClient from '../../utils/apiClient';
+import type { RepairLogEvent, RepairLogResponse } from './types';
+
+const DEFAULT_LIMIT = 25;
+
+function defaultStartDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 7);
+  return d.toISOString().split('T')[0];
+}
+
+function defaultEndDate(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function RepairLogTab(): JSX.Element {
+  const [data, setData] = useState<RepairLogResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [repairType, setRepairType] = useState<'all' | 'manual' | 'automatic'>('all');
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
+  const [page, setPage] = useState(1);
+
+  const fetchRepairLog = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (repairType !== 'all') params.set('repairType', repairType);
+      if (startDate) params.set('startDate', startDate);
+      if (endDate) params.set('endDate', endDate);
+      params.set('page', String(page));
+      params.set('limit', String(DEFAULT_LIMIT));
+
+      const response = await apiClient.get<RepairLogResponse>(
+        `/api/admin/audit-log/repairs?${params.toString()}`,
+      );
+      setData(response.data);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to fetch repair log';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [repairType, startDate, endDate, page]);
+
+  useEffect(() => {
+    fetchRepairLog();
+  }, [fetchRepairLog]);
+
+  // Reset to page 1 when filters change
+  const handleRepairTypeChange = (value: 'all' | 'manual' | 'automatic') => {
+    setRepairType(value);
+    setPage(1);
+  };
+
+  const handleStartDateChange = (value: string) => {
+    setStartDate(value);
+    setPage(1);
+  };
+
+  const handleEndDateChange = (value: string) => {
+    setEndDate(value);
+    setPage(1);
+  };
+
+  /* ---------- Loading state ---------- */
+  if (loading && !data) {
+    return (
+      <div data-testid="repair-log-tab" className="space-y-6">
+        <h2 className="text-2xl font-bold">🔧 Repair Log</h2>
+        <div className="text-center py-12 text-secondary">
+          <div className="animate-pulse">Loading repair log…</div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ---------- Error state ---------- */
+  if (error && !data) {
+    return (
+      <div data-testid="repair-log-tab" className="space-y-6">
+        <h2 className="text-2xl font-bold">🔧 Repair Log</h2>
+        <div className="bg-surface rounded-lg p-6 text-center">
+          <p className="text-error mb-4">{error}</p>
+          <button
+            onClick={fetchRepairLog}
+            className="bg-primary hover:bg-primary/80 px-6 py-2 rounded font-semibold transition-colors min-h-[44px]"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = data?.pagination.totalPages ?? 1;
+
+  return (
+    <div data-testid="repair-log-tab" className="space-y-6">
+      {/* Header with refresh */}
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">🔧 Repair Log</h2>
+        <button
+          onClick={fetchRepairLog}
+          disabled={loading}
+          className="bg-primary hover:bg-primary/80 disabled:bg-surface-elevated px-6 py-2 rounded font-semibold transition-colors min-h-[44px]"
+        >
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+
+      {/* Summary stats */}
+      {data && (
+        <div className="bg-surface rounded-lg p-6">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+            <div className="bg-surface-elevated rounded p-3">
+              <p className="text-secondary">Total Manual Repairs</p>
+              <p className="text-2xl font-bold text-success">
+                {data.summary.totalManualRepairs.toLocaleString()}
+              </p>
+            </div>
+            <div className="bg-surface-elevated rounded p-3">
+              <p className="text-secondary">Total Automatic Repairs</p>
+              <p className="text-2xl font-bold">
+                {data.summary.totalAutomaticRepairs.toLocaleString()}
+              </p>
+            </div>
+            <div className="bg-surface-elevated rounded p-3">
+              <p className="text-secondary">Total Savings</p>
+              <p className="text-2xl font-bold text-success">
+                ₡{data.summary.totalSavings.toLocaleString()}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="bg-surface rounded-lg p-6">
+        <div className="flex flex-wrap gap-4 items-end">
+          <div>
+            <label className="block text-sm text-secondary mb-1">Repair Type</label>
+            <select
+              value={repairType}
+              onChange={(e) => handleRepairTypeChange(e.target.value as 'all' | 'manual' | 'automatic')}
+              className="bg-surface-elevated text-white px-3 py-2 rounded min-h-[44px]"
+            >
+              <option value="all">All</option>
+              <option value="manual">Manual</option>
+              <option value="automatic">Automatic</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-secondary mb-1">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => handleStartDateChange(e.target.value)}
+              className="bg-surface-elevated text-white px-3 py-2 rounded min-h-[44px]"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-secondary mb-1">End Date</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => handleEndDateChange(e.target.value)}
+              className="bg-surface-elevated text-white px-3 py-2 rounded min-h-[44px]"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Data table */}
+      {data && data.events.length === 0 && (
+        <div className="bg-surface rounded-lg p-6 text-center text-secondary">
+          <p>No repair events found for the selected filters.</p>
+          <p className="text-sm mt-2">Try adjusting the date range or repair type filter.</p>
+        </div>
+      )}
+
+      {data && data.events.length > 0 && (
+        <div className="bg-surface rounded-lg p-6">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-surface-elevated">
+                <tr>
+                  <th className="p-2 lg:p-3 text-left">Player</th>
+                  <th className="p-2 lg:p-3 text-left">Robot</th>
+                  <th className="p-2 lg:p-3 text-left">Repair Type</th>
+                  <th className="p-2 lg:p-3 text-left">Cost</th>
+                  <th className="p-2 lg:p-3 text-left">Pre-Discount Cost</th>
+                  <th className="p-2 lg:p-3 text-left">Savings</th>
+                  <th className="p-2 lg:p-3 text-left">Timestamp</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.events.map((event, idx) => (
+                  <RepairEventRow key={`${event.userId}-${event.robotId}-${event.eventTimestamp}-${idx}`} event={event} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          <div className="flex justify-between items-center mt-4 text-sm">
+            <p className="text-secondary">
+              Page {data.pagination.page} of {totalPages} · {data.pagination.totalEvents.toLocaleString()} total events
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1 || loading}
+                className="bg-surface-elevated hover:bg-primary/80 disabled:opacity-50 px-4 py-2 rounded transition-colors min-h-[44px]"
+              >
+                Previous
+              </button>
+              <button
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!data.pagination.hasMore || loading}
+                className="bg-surface-elevated hover:bg-primary/80 disabled:opacity-50 px-4 py-2 rounded transition-colors min-h-[44px]"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  RepairEventRow — single repair event table row                     */
+/* ------------------------------------------------------------------ */
+
+function RepairEventRow({ event }: { event: RepairLogEvent }): JSX.Element {
+  const isManual = event.repairType === 'manual';
+  const savings =
+    isManual && event.preDiscountCost != null
+      ? event.preDiscountCost - event.cost
+      : null;
+
+  return (
+    <tr className="border-t border-white/10 hover:bg-surface-elevated">
+      <td className="p-2 lg:p-3">{event.stableName}</td>
+      <td className="p-2 lg:p-3">{event.robotName}</td>
+      <td className="p-2 lg:p-3">
+        <span
+          className={`px-2 py-1 rounded text-xs font-semibold ${
+            isManual
+              ? 'bg-green-900 text-green-300'
+              : 'bg-gray-700 text-gray-300'
+          }`}
+        >
+          {event.repairType}
+        </span>
+      </td>
+      <td className="p-2 lg:p-3">₡{event.cost.toLocaleString()}</td>
+      <td className="p-2 lg:p-3">
+        {isManual && event.preDiscountCost != null
+          ? `₡${event.preDiscountCost.toLocaleString()}`
+          : '—'}
+      </td>
+      <td className="p-2 lg:p-3">
+        {savings != null ? (
+          <span className="text-success">₡{savings.toLocaleString()}</span>
+        ) : (
+          '—'
+        )}
+      </td>
+      <td className="p-2 lg:p-3 text-secondary">
+        {new Date(event.eventTimestamp).toLocaleString()}
+      </td>
+    </tr>
+  );
+}

--- a/prototype/frontend/src/components/admin/index.ts
+++ b/prototype/frontend/src/components/admin/index.ts
@@ -9,5 +9,6 @@ export { BattleLogsTab } from './BattleLogsTab';
 export { RobotStatsTab } from './RobotStatsTab';
 export { BankruptcyMonitorTab } from './BankruptcyMonitorTab';
 export { RecentUsersTab } from './RecentUsersTab';
+export { RepairLogTab } from './RepairLogTab';
 
 export * from './types';

--- a/prototype/frontend/src/components/admin/types.ts
+++ b/prototype/frontend/src/components/admin/types.ts
@@ -245,3 +245,33 @@ export interface TagTeamBattle extends Battle {
     };
   };
 }
+
+/** Repair log event from the admin audit-log repairs endpoint */
+export interface RepairLogEvent {
+  userId: number;
+  stableName: string;
+  robotId: number;
+  robotName: string;
+  repairType: 'manual' | 'automatic';
+  cost: number;
+  preDiscountCost: number | null;
+  manualRepairDiscount: number | null;
+  eventTimestamp: string;
+}
+
+/** Response shape for GET /api/admin/audit-log/repairs */
+export interface RepairLogResponse {
+  events: RepairLogEvent[];
+  summary: {
+    totalManualRepairs: number;
+    totalAutomaticRepairs: number;
+    totalSavings: number;
+  };
+  pagination: {
+    page: number;
+    limit: number;
+    totalEvents: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
+}

--- a/prototype/frontend/src/components/onboarding/steps/Step8_BattleReadiness.tsx
+++ b/prototype/frontend/src/components/onboarding/steps/Step8_BattleReadiness.tsx
@@ -196,6 +196,19 @@ const Step8_BattleReadiness = ({ onNext, onPrevious }: Step8_BattleReadinessProp
             </p>
           </div>
 
+          <div className="bg-green-900/20 border border-green-700/50 rounded-lg p-4">
+            <h3 className="font-semibold text-success mb-2">🏷️ 50% Manual Repair Discount</h3>
+            <p className="text-gray-200 text-sm mb-2">
+              When you manually repair your robots using the <strong>"Repair All"</strong> button
+              on the Robots page, you get a <strong className="text-success">50% discount</strong> on
+              repair costs. This stacks with your Repair Bay discount.
+            </p>
+            <p className="text-secondary text-xs">
+              Automatic repairs during battle cycles pay full price. Repairing manually between
+              cycles is always cheaper — stay active to save credits.
+            </p>
+          </div>
+
           <div className="bg-surface-elevated/50 rounded-lg p-4">
             <h3 className="font-semibold text-orange-400 mb-2">📈 Higher Attributes = Higher Costs</h3>
             <p className="text-gray-200 text-sm mb-2">
@@ -387,7 +400,8 @@ const Step8_BattleReadiness = ({ onNext, onPrevious }: Step8_BattleReadinessProp
           <div className="text-sm text-gray-200">
             <strong className="text-primary">Tip:</strong> Shields are your best friend for reducing
             repair costs. Since shields regenerate for free, investing in shield attributes means
-            less HP damage and lower repair bills over time. Combine this with smart yielding for
+            less HP damage and lower repair bills over time. Combine this with smart yielding and
+            the 50% manual repair discount (use the Repair All button between cycles) for
             maximum cost efficiency.
           </div>
         </div>

--- a/prototype/frontend/src/pages/AdminPage.tsx
+++ b/prototype/frontend/src/pages/AdminPage.tsx
@@ -17,13 +17,14 @@ import {
   RobotStatsTab,
   BankruptcyMonitorTab,
   RecentUsersTab,
+  RepairLogTab,
 } from '../components/admin';
 import type { SessionLogEntry, SystemStats } from '../components/admin/types';
 import apiClient from '../utils/apiClient';
 
-type TabType = 'dashboard' | 'cycles' | 'tournaments' | 'battles' | 'stats' | 'bankruptcy-monitor' | 'recent-users';
+type TabType = 'dashboard' | 'cycles' | 'tournaments' | 'battles' | 'stats' | 'bankruptcy-monitor' | 'recent-users' | 'repair-log';
 
-const VALID_TABS: TabType[] = ['dashboard', 'cycles', 'tournaments', 'battles', 'stats', 'bankruptcy-monitor', 'recent-users'];
+const VALID_TABS: TabType[] = ['dashboard', 'cycles', 'tournaments', 'battles', 'stats', 'bankruptcy-monitor', 'recent-users', 'repair-log'];
 
 const TAB_LABELS: Record<TabType, string> = {
   dashboard: '📊 Dashboard',
@@ -33,6 +34,7 @@ const TAB_LABELS: Record<TabType, string> = {
   stats: '🤖 Robot Stats',
   'bankruptcy-monitor': '💰 Bankruptcy Monitor',
   'recent-users': '👥 Recent Users',
+  'repair-log': '🔧 Repair Log',
 };
 
 function isValidTab(value: string): value is TabType {
@@ -193,6 +195,11 @@ function AdminPage(): JSX.Element {
         {activeTab === 'recent-users' && (
           <div role="tabpanel" id="recent-users-panel" aria-labelledby="recent-users-tab">
             <RecentUsersTab />
+          </div>
+        )}
+        {activeTab === 'repair-log' && (
+          <div role="tabpanel" id="repair-log-panel" aria-labelledby="repair-log-tab">
+            <RepairLogTab />
           </div>
         )}
       </div>

--- a/prototype/frontend/src/pages/RobotsPage.tsx
+++ b/prototype/frontend/src/pages/RobotsPage.tsx
@@ -119,7 +119,7 @@ function RobotsPage() {
   const [repairBayLevel, setRepairBayLevel] = useState(0);
   const [rosterLevel, setRosterLevel] = useState(0);
   const [showRepairConfirmation, setShowRepairConfirmation] = useState(false);
-  const [repairCostInfo, setRepairCostInfo] = useState({ discountedCost: 0, discount: 0 });
+  const [repairCostInfo, setRepairCostInfo] = useState({ discountedCost: 0, discount: 0, totalBaseCost: 0 });
   const [viewMode, setViewMode] = useState<'card' | 'table'>(() => {
     const saved = localStorage.getItem('robotsViewMode');
     return (saved as 'card' | 'table') || 'card';
@@ -210,13 +210,17 @@ function RobotsPage() {
     // New formula: discount = repairBayLevel × (5 + activeRobotCount), capped at 90%
     const activeRobotCount = robots.filter(r => r.name !== 'Bye Robot').length;
     const discount = Math.min(90, repairBayLevel * (5 + activeRobotCount));
-    const discountedCost = Math.floor(totalBaseCost * (1 - discount / 100));
+    const costAfterRepairBay = Math.floor(totalBaseCost * (1 - discount / 100));
+    
+    // Apply 50% manual repair discount on top of Repair Bay discount
+    const MANUAL_REPAIR_DISCOUNT = 0.5;
+    const discountedCost = Math.floor(costAfterRepairBay * MANUAL_REPAIR_DISCOUNT);
     
     return { totalBaseCost, discountedCost, discount };
   };
 
   const handleRepairAll = async () => {
-    const { discountedCost, discount } = calculateTotalRepairCost();
+    const { totalBaseCost, discountedCost, discount } = calculateTotalRepairCost();
     
     if (discountedCost === 0) {
       alert('No robots need repair!');
@@ -224,7 +228,7 @@ function RobotsPage() {
     }
 
     // Store cost info and show confirmation modal
-    setRepairCostInfo({ discountedCost, discount });
+    setRepairCostInfo({ discountedCost, discount, totalBaseCost });
     setShowRepairConfirmation(true);
   };
 
@@ -820,19 +824,23 @@ function RobotsPage() {
               <p className="mb-2">
                 Are you sure you want to repair all robots?
               </p>
-              <div className="bg-surface-elevated p-3 rounded mt-3">
-                <div className="flex justify-between items-center">
-                  <span className="text-secondary">Total Cost:</span>
-                  <span className="text-xl font-bold text-success">
-                    ₡{repairCostInfo.discountedCost.toLocaleString()}
-                  </span>
-                </div>
+              <div className="bg-surface-elevated p-3 rounded mt-3 space-y-2">
                 {repairCostInfo.discount > 0 && (
-                  <div className="flex justify-between items-center mt-1 text-sm">
+                  <div className="flex justify-between items-center text-sm">
                     <span className="text-tertiary">Repair Bay Discount:</span>
                     <span className="text-primary">{repairCostInfo.discount}% off</span>
                   </div>
                 )}
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-tertiary">Manual Repair Discount:</span>
+                  <span className="text-primary">50% off</span>
+                </div>
+                <div className="border-t border-white/10 pt-2 flex justify-between items-center">
+                  <span className="text-secondary">Final Cost:</span>
+                  <span className="text-xl font-bold text-success">
+                    ₡{repairCostInfo.discountedCost.toLocaleString()}
+                  </span>
+                </div>
               </div>
             </div>
           }

--- a/prototype/frontend/src/pages/__tests__/AdminPage.test.tsx
+++ b/prototype/frontend/src/pages/__tests__/AdminPage.test.tsx
@@ -52,6 +52,7 @@ const TAB_LABELS = [
   '🤖 Robot Stats',
   '💰 Bankruptcy Monitor',
   '👥 Recent Users',
+  '🔧 Repair Log',
 ];
 
 function renderAdminPage() {
@@ -72,7 +73,7 @@ describe('AdminPage shell', () => {
   it('should render all 7 tab buttons', () => {
     renderAdminPage();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(7);
+    expect(tabs).toHaveLength(8);
     for (const label of TAB_LABELS) {
       expect(screen.getByRole('tab', { name: label })).toBeInTheDocument();
     }


### PR DESCRIPTION
- Backend: Apply 50% discount on manual repairs (Repair All button) after Repair Bay discount, keep automatic cycle repairs at full price
- Backend: Add repairType field to audit log (manual vs automatic)
- Backend: Add GET /api/admin/audit-log/repairs endpoint with filtering
- Frontend: Show manual discount breakdown in repair confirmation modal
- Frontend: Add RepairLogTab to admin portal with summary stats and filters
- Docs: Update PRDs (economy, onboarding, robots list page), admin guide, repair cost implementation notes
- Guide: Update 4 in-game guide articles with manual repair discount info
- Tests: Property-based tests (fast-check), unit tests, admin endpoint tests
- Spec: Add manual-repair-cost-reduction spec files