### PR TITLE
feat: add scouting links and show all battles for non-owned robots

### DIFF
--- a/prototype/backend/src/routes/matches.ts
+++ b/prototype/backend/src/routes/matches.ts
@@ -443,12 +443,8 @@ router.get('/history', authenticateToken, async (req: AuthRequest, res: Response
 
     const robotIds = userRobots.map(r => r.id);
 
-    // If robotId filter is provided, verify ownership
-    if (robotId !== undefined && !robotIds.includes(robotId)) {
-      return res.status(403).json({ error: 'Access denied to robot data' });
-    }
-
-    // Build where clause
+    // If robotId filter is provided, allow viewing any robot's battles (public scouting)
+    // If no robotId, default to showing only the current user's robot battles
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const whereClause: Record<string, any> = {
       OR: [
@@ -847,6 +843,8 @@ router.get('/battles/:id/log', authenticateToken, async (req: AuthRequest, res: 
         id: battleData.robot1.id,
         name: battleData.robot1.name,
         owner: battleData.robot1.user.username,
+        maxHP: battleData.robot1.maxHP,
+        maxShield: battleData.robot1.maxShield,
         eloBefore: robot1Participant?.eloBefore || 0,
         eloAfter: robot1Participant?.eloAfter || 0,
         finalHP: robot1Participant?.finalHP ?? 0,
@@ -861,6 +859,8 @@ router.get('/battles/:id/log', authenticateToken, async (req: AuthRequest, res: 
         id: battleData.robot2.id,
         name: battleData.robot2.name,
         owner: battleData.robot2.user.username,
+        maxHP: battleData.robot2.maxHP,
+        maxShield: battleData.robot2.maxShield,
         eloBefore: robot2Participant?.eloBefore || 0,
         eloAfter: robot2Participant?.eloAfter || 0,
         finalHP: robot2Participant?.finalHP ?? 0,

--- a/prototype/frontend/src/components/UpcomingMatches.tsx
+++ b/prototype/frontend/src/components/UpcomingMatches.tsx
@@ -488,7 +488,12 @@ function UpcomingMatches({ robotId, battleReadiness }: UpcomingMatchesProps = {}
                   <div className="font-medium text-xs truncate">
                     <span className="text-[#58a6ff]">{myRobot.name}</span>
                     <span className="text-[#57606a] mx-1.5">vs</span>
-                    <span className="text-[#e6edf3]">{opponent.name}</span>
+                    <span 
+                      className="text-[#e6edf3] hover:text-[#58a6ff] cursor-pointer hover:underline transition-colors"
+                      onClick={(e) => { e.stopPropagation(); navigate(`/robots/${opponent.id}`); }}
+                    >
+                      {opponent.name}
+                    </span>
                   </div>
                 </div>
                 
@@ -535,7 +540,12 @@ function UpcomingMatches({ robotId, battleReadiness }: UpcomingMatchesProps = {}
                   <div className="text-sm font-medium">
                     <span className="text-[#58a6ff]">{myRobot.name}</span>
                     <span className="text-[#57606a] mx-1.5">vs</span>
-                    <span className="text-[#e6edf3]">{opponent.name}</span>
+                    <span 
+                      className="text-[#e6edf3] hover:text-[#58a6ff] cursor-pointer hover:underline transition-colors"
+                      onClick={(e) => { e.stopPropagation(); navigate(`/robots/${opponent.id}`); }}
+                    >
+                      {opponent.name}
+                    </span>
                   </div>
                 </div>
                 

--- a/prototype/frontend/src/pages/LeagueStandingsPage.tsx
+++ b/prototype/frontend/src/pages/LeagueStandingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import Navigation from '../components/Navigation';
 import { fetchMyRobots } from '../utils/robotApi';
 import {
@@ -16,6 +17,7 @@ const TIERS = ['bronze', 'silver', 'gold', 'platinum', 'diamond', 'champion'];
 
 function LeagueStandingsPage() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [selectedTier, setSelectedTier] = useState('bronze');
   const [selectedInstance, setSelectedInstance] = useState<string | null>(null);
   const [robots, setRobots] = useState<LeagueRobot[]>([]);
@@ -263,7 +265,10 @@ function LeagueStandingsPage() {
                             #{rank}
                           </td>
                           <td className="px-1.5 lg:px-4 py-3">
-                            <div className={`font-semibold text-sm lg:text-base truncate max-w-[100px] lg:max-w-none ${isMyBot ? 'text-primary' : ''}`}>
+                            <div 
+                              className={`font-semibold text-sm lg:text-base truncate max-w-[100px] lg:max-w-none cursor-pointer hover:underline transition-colors ${isMyBot ? 'text-primary hover:text-blue-300' : 'hover:text-[#58a6ff]'}`}
+                              onClick={() => navigate(`/robots/${robot.id}`)}
+                            >
                               {robot.name}
                             </div>
                           </td>

--- a/prototype/frontend/src/pages/RobotDetailPage.tsx
+++ b/prototype/frontend/src/pages/RobotDetailPage.tsx
@@ -305,26 +305,14 @@ function RobotDetailPage() {
         console.error('Failed to fetch facilities:', err);
       }
 
-      // Fetch recent battles using the same API as battle history
-      const recentBattlesData = await getMatchHistory(1, 10);
-      
-      // Filter for this specific robot
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const robotBattles = recentBattlesData.data.filter((battle: any) => {
-        // Check if this robot participated in the battle
-        if (battle.battleType === 'tag_team') {
-          return (
-            battle.team1ActiveRobotId === parseInt(id!) ||
-            battle.team1ReserveRobotId === parseInt(id!) ||
-            battle.team2ActiveRobotId === parseInt(id!) ||
-            battle.team2ReserveRobotId === parseInt(id!)
-          );
-        } else {
-          return battle.robot1Id === parseInt(id!) || battle.robot2Id === parseInt(id!);
-        }
-      });
-      
-      setRecentBattles(robotBattles);
+      // Fetch recent battles for this specific robot via API
+      try {
+        const recentBattlesData = await getMatchHistory(1, 10, undefined, parseInt(id!));
+        setRecentBattles(recentBattlesData.data);
+      } catch (err) {
+        console.error('Failed to fetch recent battles:', err);
+        // Don't fail the entire page if battle history fails
+      }
 
       // Calculate battle readiness
       const hpPercentage = (robotData.currentHP / robotData.maxHP) * 100;

--- a/prototype/frontend/src/utils/matchmakingApi.ts
+++ b/prototype/frontend/src/utils/matchmakingApi.ts
@@ -197,7 +197,8 @@ export const getUpcomingMatches = async (): Promise<ScheduledMatch[]> => {
 export const getMatchHistory = async (
   page: number = 1,
   pageSize: number = 10,
-  battleType?: 'overall' | 'league' | 'tournament' | 'tag_team'
+  battleType?: 'overall' | 'league' | 'tournament' | 'tag_team',
+  robotId?: number
 ): Promise<PaginatedResponse<BattleHistory>> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const params: any = { page, perPage: pageSize };
@@ -205,6 +206,11 @@ export const getMatchHistory = async (
   // Add battleType filter if not 'overall'
   if (battleType && battleType !== 'overall') {
     params.battleType = battleType;
+  }
+
+  // Add robotId filter to fetch battles for a specific robot
+  if (robotId) {
+    params.robotId = robotId;
   }
   
   console.log('[API] getMatchHistory params:', params);
@@ -377,6 +383,8 @@ export interface BattleLogResponse {
     id: number;
     name: string;
     owner: string;
+    maxHP?: number;
+    maxShield?: number;
     eloBefore: number;
     eloAfter: number;
     finalHP: number;
@@ -399,6 +407,8 @@ export interface BattleLogResponse {
     id: number;
     name: string;
     owner: string;
+    maxHP?: number;
+    maxShield?: number;
     eloBefore: number;
     eloAfter: number;
     finalHP: number;
@@ -420,11 +430,17 @@ export interface BattleLogResponse {
   winner: 'robot1' | 'robot2' | null;
   battleLog: {
     events: BattleLogEvent[];
+    // Raw simulator events with full spatial data (positions, HP, shields)
+    detailedCombatEvents?: BattleLogEvent[];
     // Tournament metadata
     isTournament?: boolean;
     round?: number;
     maxRounds?: number;
     isFinals?: boolean;
+    // 2D arena spatial metadata
+    arenaRadius?: number;
+    startingPositions?: Record<string, { x: number; y: number }>;
+    endingPositions?: Record<string, { x: number; y: number }>;
   };
   // Tag team specific fields
   tagTeam?: {


### PR DESCRIPTION
- Make opponent names clickable in Upcoming Matches (league/tournament 1v1 only, not tag team)
- Make robot names clickable in League Standings to navigate to /robots/:id
- Remove ownership restriction on /api/matches/history robotId filter for public scouting
- Pass robotId to getMatchHistory on robot detail page for non-owned robots
- Wrap battle history fetch in try-catch to prevent logout on failure