### PR TITLE
fix: remove test files from tsconfig build include

### DIFF
--- a/prototype/backend/tsconfig.json
+++ b/prototype/backend/tsconfig.json
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*", "tests/project-quality-preservation.pbt.test.ts", "tests/project-quality-audit.pbt.test.ts"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/__tests__", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Test files should only be compiled by Jest/ts-jest, not by the tsc build. Having them in include with rootDir=./src causes TS6059 in CI.