### PR TITLE
fix: increase E2E DB connection_limit to 20 and retry on API errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,13 +206,13 @@ jobs:
       - name: Run database migrations
         working-directory: ./app/backend
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=5
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=20
         run: npx prisma migrate deploy
 
       - name: Seed database
         working-directory: ./app/backend
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=5
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=20
         run: npx prisma db seed
 
       - name: Build backend
@@ -222,7 +222,7 @@ jobs:
       - name: Start backend server
         working-directory: ./app/backend
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=5
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/armouredsouls_e2e?connection_limit=20
           JWT_SECRET: test-secret-key-for-ci
           NODE_ENV: test
           PORT: 3001

--- a/app/frontend/tests/e2e/weapon-shop.spec.ts
+++ b/app/frontend/tests/e2e/weapon-shop.spec.ts
@@ -4,7 +4,7 @@ import { navigateToProtectedPage } from './helpers/navigate';
 /**
  * Navigate to the weapon shop and ensure the page has fully loaded.
  * Retries navigation up to 3 times if the page gets stuck in a loading
- * or error state (transient backend hiccups in CI).
+ * or error state (transient backend/DB connection issues in CI).
  */
 async function navigateToWeaponShop(page: import('@playwright/test').Page) {
   const filtersHeading = page.getByRole('heading', { name: 'Filters', exact: true });
@@ -19,6 +19,16 @@ async function navigateToWeaponShop(page: import('@playwright/test').Page) {
 
     if (await filtersHeading.isVisible({ timeout: 10000 }).catch(() => false)) {
       return; // Page loaded successfully
+    }
+
+    // If the page shows an error with a Retry button, click it
+    const retryButton = page.getByRole('button', { name: 'Retry' });
+    if (await retryButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await retryButton.click();
+      await page.waitForLoadState('networkidle');
+      if (await filtersHeading.isVisible({ timeout: 10000 }).catch(() => false)) {
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Root cause: the CI screenshots show 'Failed to load weapons' — the weapons API returns an error because the Prisma connection pool (connection_limit=5) is exhausted when onboarding/registration tests run concurrent DB-heavy operations alongside weapon shop page loads.

Fix:
- Bump connection_limit from 5 to 20 in the E2E CI job
- Add Retry button click in navigateToWeaponShop helper so transient API failures are recovered automatically