### PR TITLE
fix: per-tier LP promotion thresholds and KotH tab color

### DIFF
--- a/.kiro/specs/done-march26/in-game-guide/requirements.md
+++ b/.kiro/specs/done-march26/in-game-guide/requirements.md
@@ -116,7 +116,7 @@ Armoured Souls is a complex robot combat strategy game with many interconnected 
 1. THE Guide SHALL include an article explaining the six league tiers (Bronze, Silver, Gold, Platinum, Diamond, Champion) and the instance system (max 100 robots per instance)
 2. THE Guide SHALL include an article explaining the matchmaking algorithm: LP-primary matching (±10 LP ideal, ±20 LP fallback) with ELO as secondary quality check
 3. THE Guide SHALL include an article explaining League Points (LP) earning (+3 win, -1 loss, +1 draw) and their role in promotion
-4. THE Guide SHALL include an article explaining promotion requirements (top 10% of instance + ≥25 LP + ≥5 cycles in tier) and demotion rules (bottom 10% + ≥5 cycles)
+4. THE Guide SHALL include an article explaining promotion requirements (top 10% of instance + per-tier LP threshold + ≥5 cycles in tier) and demotion rules (bottom 10% + ≥5 cycles)
 5. THE Guide SHALL include an article explaining LP retention across tier changes and the automatic 5-cycle demotion protection for newly promoted robots
 6. THE Guide SHALL include a diagram showing the league tier progression path from Bronze to Champion
 

--- a/.kiro/specs/done-march26/tag-team-matches/requirements.md
+++ b/.kiro/specs/done-march26/tag-team-matches/requirements.md
@@ -99,7 +99,7 @@ The feature integrates with the existing battle system: when the first robot rea
 
 1. THE System SHALL maintain six tag team league tiers (Bronze, Silver, Gold, Platinum, Diamond, Champion)
 2. WHEN a new tag team is formed, THE System SHALL place it in the Bronze tag team league
-3. WHEN tag team league rebalancing occurs, THE System SHALL promote teams in the top 10% with ≥25 tag team league points (minimum 5 cycles in current tier)
+3. WHEN tag team league rebalancing occurs, THE System SHALL promote teams in the top 10% with per-tier LP threshold (minimum 5 cycles in current tier)
 4. WHEN tag team league rebalancing occurs, THE System SHALL demote the bottom 10% of teams (minimum 5 cycles in current tier)
 5. WHEN a team is promoted or demoted, THE System SHALL reset their tag team league points to 0
 6. WHEN a team is promoted or demoted, THE System SHALL reset their cycles counter to 0

--- a/app/backend/src/content/guide/getting-started/daily-cycle.md
+++ b/app/backend/src/content/guide/getting-started/daily-cycle.md
@@ -60,7 +60,7 @@ This is the main event — your 1v1 league battles.
 
 1. **Repair all robots** — Full repair pass with costs deducted, so every robot enters league battles at full health.
 2. **Execute league battles** — All 1v1 matches that were scheduled during the previous cycle's matchmaking are fought. Results include ELO changes, LP gains/losses, credits earned, and streaming revenue.
-3. **Rebalance leagues** — Robots in the top 10% of their league instance (with ≥25 LP and ≥5 cycles in the tier) are promoted. Bottom 10% (with ≥5 cycles) are demoted. Instances are rebalanced if they exceed the 100-robot cap.
+3. **Rebalance leagues** — Robots in the top 10% of their league instance (meeting the per-tier LP threshold and ≥5 cycles in the tier) are promoted. Bottom 10% (with ≥5 cycles) are demoted. Instances are rebalanced if they exceed the 100-robot cap.
 4. **League matchmaking** — New 1v1 matches are scheduled for the next cycle (24-hour lead time). Robots are paired primarily by LP (±10 ideal, ±20 fallback), with ELO as a secondary quality check.
 
 ```callout-tip

--- a/app/backend/src/content/guide/leagues/promotion-demotion.md
+++ b/app/backend/src/content/guide/leagues/promotion-demotion.md
@@ -2,7 +2,7 @@
 title: "Promotion & Demotion"
 description: "How robots earn promotion to higher tiers and face demotion to lower ones — the requirements, timing, protection mechanics, and LP retention that govern league progression."
 order: 4
-lastUpdated: "2026-03-12"
+lastUpdated: "2026-04-18"
 relatedArticles:
   - leagues/league-points
   - leagues/league-tiers
@@ -31,10 +31,10 @@ flowchart TD
     C["🏆 Champion\nThe pinnacle\nNo promotion beyond this"]
 
     B -->|"Promote: Top 10% + ≥25 LP + ≥5 cycles"| S
-    S -->|"Promote"| G
-    G -->|"Promote"| P
-    P -->|"Promote"| D
-    D -->|"Promote"| C
+    S -->|"Promote: Top 10% + ≥50 LP + ≥5 cycles"| G
+    G -->|"Promote: Top 10% + ≥75 LP + ≥5 cycles"| P
+    P -->|"Promote: Top 10% + ≥100 LP + ≥5 cycles"| D
+    D -->|"Promote: Top 10% + ≥125 LP + ≥5 cycles"| C
 
     S -->|"Demote: Bottom 10% + ≥5 cycles"| B
     G -->|"Demote"| S
@@ -50,7 +50,7 @@ flowchart TD
     style C fill:#9d4edd,stroke:#7b2cbf,color:#fff
 ```
 
-Each arrow represents a tier change. Promotion requires meeting all three criteria (top 10% of instance, ≥25 LP, ≥5 cycles). Demotion requires being in the bottom 10% after ≥5 cycles. Bronze has no demotion, and Champion has no promotion.
+Each arrow represents a tier change. Promotion requires meeting all three criteria (top 10% of instance, per-tier LP threshold, ≥5 cycles). Demotion requires being in the bottom 10% after ≥5 cycles. Bronze has no demotion, and Champion has no promotion.
 
 ## Promotion Requirements
 
@@ -59,14 +59,14 @@ To be promoted to the next tier, your robot must meet **all three** of these con
 | Requirement | Threshold | Why It Exists |
 |-------------|-----------|---------------|
 | **Instance Rank** | Top 10% of your instance | Ensures you're outperforming most of your direct competition |
-| **League Points** | ≥25 LP | Proves sustained winning performance, not just a lucky cycle |
+| **League Points** | Per-tier threshold (see below) | Proves sustained winning performance, not just a lucky cycle |
 | **Time in Tier** | ≥5 cycles in current tier | Prevents premature promotion before you've established yourself |
 
 All three must be true at the same time. Missing even one means you stay in your current tier until the next cycle evaluation.
 
 ### LP Required Per Promotion
 
-The LP threshold is a flat **25 LP** at every tier. Because LP carries over when you're promoted, you don't reset to 0 — but you still need to have at least 25 LP at the moment of each evaluation.
+Higher tiers demand more LP to earn promotion. The thresholds increase by 25 LP per tier, reflecting the greater challenge of climbing through stronger competition. Because LP carries over when you're promoted, you don't reset to 0 — but you need to reach the next tier's threshold to keep climbing.
 
 | Promotion | LP Required | Notes |
 |-----------|-------------|-------|
@@ -77,7 +77,7 @@ The LP threshold is a flat **25 LP** at every tier. Because LP carries over when
 | Diamond → Champion | ≥125 LP | The final gate. Only the top performers in Diamond break through. |
 
 ```callout-info
-Since LP carries over, a robot promoted with 32 LP enters the next tier with 32 LP — already above the 25 LP threshold. But tougher opponents in the new tier may push your LP down before the next evaluation. The real challenge isn't reaching 25 LP once — it's staying above it while competing against stronger robots.
+Since LP carries over, a robot promoted from Bronze with 32 LP enters Silver with 32 LP. But the Silver→Gold threshold is 50 LP, so you'll need to keep winning to reach it. Tougher opponents in the new tier may slow your LP growth — the real challenge is building momentum against stronger competition.
 ```
 
 ### How the Top 10% Works
@@ -220,13 +220,15 @@ Here's what a typical progression from Bronze to Gold might look like:
 - Opponents are stronger — win rate may drop to 45-50% initially
 - 5-cycle protection gives you breathing room
 - LP may dip slightly during adjustment, then stabilize
+- Need to reach 50 LP for Gold promotion (higher threshold than Bronze→Silver)
 - By cycle 25-30, you've adapted, rebuilt LP, and are pushing top 10% again
 - **Promoted to Gold** around cycle 28-32
 
 ### Phase 3: Gold and Beyond
 
 - Each tier takes longer to master as competition intensifies
-- The 25 LP threshold remains constant, but earning LP is harder against better opponents
+- LP thresholds increase: 75 for Platinum, 100 for Diamond, 125 for Champion
+- Earning LP is harder against better opponents
 - Expect 15-25 cycles per tier at higher levels
 - Not every robot reaches Champion — and that's by design
 

--- a/app/backend/src/services/league/leaguePromotionThresholds.ts
+++ b/app/backend/src/services/league/leaguePromotionThresholds.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-tier LP thresholds for league promotion.
+ * Shared between 1v1 and tag team league rebalancing services.
+ *
+ * Higher tiers require more LP to earn promotion:
+ *   Bronze → Silver: 25 LP
+ *   Silver → Gold:   50 LP
+ *   Gold → Platinum: 75 LP
+ *   Platinum → Diamond: 100 LP
+ *   Diamond → Champion: 125 LP
+ */
+
+// Use a generic string-keyed record so both LeagueTier and TagTeamLeagueTier work
+// without creating a circular dependency between instance services.
+const PROMOTION_LP_THRESHOLDS: Readonly<Record<string, number>> = {
+  bronze: 25,
+  silver: 50,
+  gold: 75,
+  platinum: 100,
+  diamond: 125,
+  champion: Infinity, // Cannot promote from Champion
+} as const;
+
+/**
+ * Get the minimum LP required for promotion from a given tier.
+ * Returns 25 as a safe default for unknown tier values.
+ */
+export function getMinLPForPromotion(tier: string): number {
+  return PROMOTION_LP_THRESHOLDS[tier] ?? 25;
+}
+
+export { PROMOTION_LP_THRESHOLDS };

--- a/app/backend/src/services/league/leagueRebalancingService.ts
+++ b/app/backend/src/services/league/leagueRebalancingService.ts
@@ -16,11 +16,26 @@ import {
 } from './leagueInstanceService';
 
 // Promotion/Demotion thresholds
-const MIN_LEAGUE_POINTS_FOR_PROMOTION = 25; // Must have 25+ league points for promotion
+// Per-tier LP thresholds: higher tiers require more LP to promote
+const PROMOTION_LP_THRESHOLDS: Record<string, number> = {
+  bronze: 25,   // Bronze → Silver
+  silver: 50,   // Silver → Gold
+  gold: 75,     // Gold → Platinum
+  platinum: 100, // Platinum → Diamond
+  diamond: 125,  // Diamond → Champion
+  champion: Infinity, // Cannot promote from Champion
+};
 const PROMOTION_PERCENTAGE = 0.10; // Top 10%
 const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_ROBOTS_FOR_REBALANCING = 10;
+
+/**
+ * Get the minimum LP required for promotion from a given tier
+ */
+export function getMinLPForPromotion(tier: string): number {
+  return PROMOTION_LP_THRESHOLDS[tier] ?? 25;
+}
 
 export interface RebalancingSummary {
   tier: LeagueTier;
@@ -40,7 +55,8 @@ export interface FullRebalancingSummary {
 
 /**
  * Determine which robots should be promoted from a SPECIFIC INSTANCE
- * Robots must have ≥25 league points AND be in top 10% AND ≥5 cycles in current league
+ * Robots must meet per-tier LP threshold AND be in top 10% AND ≥5 cycles in current league
+ * LP thresholds: Bronze→Silver 25, Silver→Gold 50, Gold→Platinum 75, Platinum→Diamond 100, Diamond→Champion 125
  * @param instanceId - The specific league instance to evaluate (e.g., "bronze_1")
  * @param excludeRobotIds - Set of robot IDs to exclude (already processed in this cycle)
  */
@@ -52,6 +68,9 @@ export async function determinePromotions(instanceId: string, excludeRobotIds: S
     return [];
   }
 
+  // Get the per-tier LP threshold for promotion
+  const minLP = getMinLPForPromotion(tier);
+
   // Get all robots in this INSTANCE with minimum cycles AND minimum league points
   const robotsWithMinPoints = await prisma.robot.findMany({
     where: {
@@ -60,7 +79,7 @@ export async function determinePromotions(instanceId: string, excludeRobotIds: S
         gte: MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING,
       },
       leaguePoints: {
-        gte: MIN_LEAGUE_POINTS_FOR_PROMOTION,
+        gte: minLP,
       },
       NOT: [
         { name: 'Bye Robot' },
@@ -75,7 +94,7 @@ export async function determinePromotions(instanceId: string, excludeRobotIds: S
 
   // If no robots meet the minimum points threshold, skip
   if (robotsWithMinPoints.length === 0) {
-    logger.info(`[Rebalancing] ${instanceId}: No robots with ≥${MIN_LEAGUE_POINTS_FOR_PROMOTION} league points, skipping promotions`);
+    logger.info(`[Rebalancing] ${instanceId}: No robots with ≥${minLP} league points (${tier} tier threshold), skipping promotions`);
     return [];
   }
 
@@ -107,10 +126,10 @@ export async function determinePromotions(instanceId: string, excludeRobotIds: S
     return [];
   }
 
-  // Take the top 10%, but only from robots with ≥25 league points
+  // Take the top 10%, but only from robots meeting the per-tier LP threshold
   const toPromote = robotsWithMinPoints.slice(0, Math.min(promotionCount, robotsWithMinPoints.length));
   
-  logger.info(`[Rebalancing] ${instanceId}: ${toPromote.length} robots eligible for promotion (top ${PROMOTION_PERCENTAGE * 100}% of ${totalEligibleRobots} AND ≥${MIN_LEAGUE_POINTS_FOR_PROMOTION} league points, ${robotsWithMinPoints.length} met points threshold)`);
+  logger.info(`[Rebalancing] ${instanceId}: ${toPromote.length} robots eligible for promotion (top ${PROMOTION_PERCENTAGE * 100}% of ${totalEligibleRobots} AND ≥${minLP} league points [${tier} tier], ${robotsWithMinPoints.length} met points threshold)`);
   
   return toPromote;
 }

--- a/app/backend/src/services/league/leagueRebalancingService.ts
+++ b/app/backend/src/services/league/leagueRebalancingService.ts
@@ -14,28 +14,16 @@ import {
   LeagueTier,
   getInstancesForTier,
 } from './leagueInstanceService';
+import { getMinLPForPromotion } from './leaguePromotionThresholds';
 
 // Promotion/Demotion thresholds
-// Per-tier LP thresholds: higher tiers require more LP to promote
-const PROMOTION_LP_THRESHOLDS: Record<string, number> = {
-  bronze: 25,   // Bronze → Silver
-  silver: 50,   // Silver → Gold
-  gold: 75,     // Gold → Platinum
-  platinum: 100, // Platinum → Diamond
-  diamond: 125,  // Diamond → Champion
-  champion: Infinity, // Cannot promote from Champion
-};
 const PROMOTION_PERCENTAGE = 0.10; // Top 10%
 const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_ROBOTS_FOR_REBALANCING = 10;
 
-/**
- * Get the minimum LP required for promotion from a given tier
- */
-export function getMinLPForPromotion(tier: string): number {
-  return PROMOTION_LP_THRESHOLDS[tier] ?? 25;
-}
+// Re-export for consumers that need the helper
+export { getMinLPForPromotion } from './leaguePromotionThresholds';
 
 export interface RebalancingSummary {
   tier: LeagueTier;

--- a/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
+++ b/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
@@ -13,28 +13,16 @@ import {
   TAG_TEAM_LEAGUE_TIERS,
   TagTeamLeagueTier 
 } from './tagTeamLeagueInstanceService';
+import { getMinLPForPromotion } from '../league/leaguePromotionThresholds';
 
 // Promotion/Demotion thresholds
-// Per-tier LP thresholds: higher tiers require more LP to promote
-const PROMOTION_LP_THRESHOLDS: Record<string, number> = {
-  bronze: 25,   // Bronze → Silver
-  silver: 50,   // Silver → Gold
-  gold: 75,     // Gold → Platinum
-  platinum: 100, // Platinum → Diamond
-  diamond: 125,  // Diamond → Champion
-  champion: Infinity, // Cannot promote from Champion
-};
 const PROMOTION_PERCENTAGE = 0.10; // Top 10%
 const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_TEAMS_FOR_REBALANCING = 10;
 
-/**
- * Get the minimum LP required for promotion from a given tier
- */
-export function getMinLPForPromotion(tier: string): number {
-  return PROMOTION_LP_THRESHOLDS[tier] ?? 25;
-}
+// Re-export for consumers that need the helper
+export { getMinLPForPromotion } from '../league/leaguePromotionThresholds';
 
 // Re-export from instance service for convenience
 export { TAG_TEAM_LEAGUE_TIERS, TagTeamLeagueTier };

--- a/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
+++ b/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
@@ -15,11 +15,26 @@ import {
 } from './tagTeamLeagueInstanceService';
 
 // Promotion/Demotion thresholds
-const MIN_LEAGUE_POINTS_FOR_PROMOTION = 25; // Must have 25+ league points for promotion
+// Per-tier LP thresholds: higher tiers require more LP to promote
+const PROMOTION_LP_THRESHOLDS: Record<string, number> = {
+  bronze: 25,   // Bronze → Silver
+  silver: 50,   // Silver → Gold
+  gold: 75,     // Gold → Platinum
+  platinum: 100, // Platinum → Diamond
+  diamond: 125,  // Diamond → Champion
+  champion: Infinity, // Cannot promote from Champion
+};
 const PROMOTION_PERCENTAGE = 0.10; // Top 10%
 const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_TEAMS_FOR_REBALANCING = 10;
+
+/**
+ * Get the minimum LP required for promotion from a given tier
+ */
+export function getMinLPForPromotion(tier: string): number {
+  return PROMOTION_LP_THRESHOLDS[tier] ?? 25;
+}
 
 // Re-export from instance service for convenience
 export { TAG_TEAM_LEAGUE_TIERS, TagTeamLeagueTier };
@@ -42,7 +57,8 @@ export interface FullTagTeamRebalancingSummary {
 
 /**
  * Determine which teams should be promoted from a SPECIFIC INSTANCE
- * Requirement 6.3: Promote top 10% of eligible teams (≥5 cycles in tier AND ≥25 league points)
+ * Requirement 6.3: Promote top 10% of eligible teams (≥5 cycles in tier AND per-tier LP threshold)
+ * LP thresholds: Bronze→Silver 25, Silver→Gold 50, Gold→Platinum 75, Platinum→Diamond 100, Diamond→Champion 125
  * @param instanceId - The specific league instance to evaluate (e.g., "bronze_1")
  * @param excludeTeamIds - Set of team IDs to exclude (already processed in this cycle)
  */
@@ -57,6 +73,9 @@ export async function determinePromotions(
     return [];
   }
 
+  // Get the per-tier LP threshold for promotion
+  const minLP = getMinLPForPromotion(tier);
+
   // Get all teams in this INSTANCE with minimum cycles AND minimum league points
   const teamsWithMinPoints = await prisma.tagTeam.findMany({
     where: {
@@ -65,7 +84,7 @@ export async function determinePromotions(
         gte: MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING,
       },
       tagTeamLeaguePoints: {
-        gte: MIN_LEAGUE_POINTS_FOR_PROMOTION,
+        gte: minLP,
       },
       NOT: {
         id: { in: Array.from(excludeTeamIds) },
@@ -80,7 +99,7 @@ export async function determinePromotions(
   // If no teams meet the minimum points threshold, skip
   if (teamsWithMinPoints.length === 0) {
     logger.info(
-      `[TagTeamRebalancing] ${instanceId}: No teams with ≥${MIN_LEAGUE_POINTS_FOR_PROMOTION} league points, skipping promotions`
+      `[TagTeamRebalancing] ${instanceId}: No teams with ≥${minLP} league points (${tier} tier threshold), skipping promotions`
     );
     return [];
   }
@@ -116,11 +135,11 @@ export async function determinePromotions(
     return [];
   }
 
-  // Take the top 10%, but only from teams with ≥25 league points
+  // Take the top 10%, but only from teams meeting the per-tier LP threshold
   const toPromote = teamsWithMinPoints.slice(0, Math.min(promotionCount, teamsWithMinPoints.length));
   
   logger.info(
-    `[TagTeamRebalancing] ${instanceId}: ${toPromote.length} teams eligible for promotion (top ${PROMOTION_PERCENTAGE * 100}% of ${totalEligibleTeams} AND ≥${MIN_LEAGUE_POINTS_FOR_PROMOTION} league points, ${teamsWithMinPoints.length} met points threshold)`
+    `[TagTeamRebalancing] ${instanceId}: ${toPromote.length} teams eligible for promotion (top ${PROMOTION_PERCENTAGE * 100}% of ${totalEligibleTeams} AND ≥${minLP} league points [${tier} tier], ${teamsWithMinPoints.length} met points threshold)`
   );
 
   return toPromote;

--- a/app/backend/tests/leagueRebalancingService.test.ts
+++ b/app/backend/tests/leagueRebalancingService.test.ts
@@ -5,6 +5,7 @@ import {
   promoteRobot,
   demoteRobot,
   rebalanceLeagues,
+  getMinLPForPromotion,
 } from '../src/services/league/leagueRebalancingService';
 
 
@@ -69,7 +70,7 @@ describe('League Rebalancing Service', () => {
   });
 
   describe('determinePromotions', () => {
-    it('should return top 10% of robots with ≥5 cycles AND ≥25 league points', async () => {
+    it('should return top 10% of robots with ≥5 cycles AND per-tier LP threshold', async () => {
       // Create 20 robots in bronze league with varying league points
       const robots = [];
       for (let i = 0; i < 20; i++) {
@@ -88,7 +89,7 @@ describe('League Rebalancing Service', () => {
             currentShield: 2,
             maxShield: 2,
             elo: 1200,
-            leaguePoints: i * 5, // 0, 5, 10, ..., 95 (robots 5+ have ≥25 points)
+            leaguePoints: i * 5, // 0, 5, 10, ..., 95 (robots 5+ have ≥25 points — bronze threshold)
             totalBattles: 10,
             cyclesInCurrentLeague: 10, // All have enough cycles in current league
             loadoutType: 'single',
@@ -100,7 +101,7 @@ describe('League Rebalancing Service', () => {
 
       const toPromote = await determinePromotions('bronze_1'); // Changed to instance ID
 
-      // Should get top 10% of 20 = 2 robots, but only from those with ≥25 points
+      // Should get top 10% of 20 = 2 robots, but only from those with ≥25 points (bronze threshold)
       // Robots 5-19 have ≥25 points (15 robots), top 2 are robots 19 and 18
       expect(toPromote.length).toBe(2);
       expect(toPromote[0].name).toBe('Bronze Robot 19'); // 95 points
@@ -146,7 +147,7 @@ describe('League Rebalancing Service', () => {
       const toPromote = await determinePromotions('bronze_1'); // Changed to instance ID
 
       // Should only consider robots with ≥5 cycles in current league (last 10 robots)
-      // 10% of 10 = 1 robot, and must have ≥25 points
+      // 10% of 10 = 1 robot, and must have ≥25 points (bronze threshold)
       // Robots 10-19 have ≥5 cycles, robots 5-19 have ≥25 points
       // So robots 10-19 meet both criteria (10 robots), top 10% = 1 robot
       expect(toPromote.length).toBe(1);
@@ -165,8 +166,8 @@ describe('League Rebalancing Service', () => {
       expect(toPromote).toEqual([]);
     });
 
-    it('should return empty array when no robots have ≥25 league points', async () => {
-      // Create 20 robots but none with ≥25 league points
+    it('should return empty array when no robots meet per-tier LP threshold', async () => {
+      // Create 20 robots but none with ≥25 league points (bronze threshold)
       const robots = [];
       for (let i = 0; i < 20; i++) {
         const weaponInv = await prisma.weaponInventory.create({
@@ -195,6 +196,93 @@ describe('League Rebalancing Service', () => {
       }
 
       const toPromote = await determinePromotions('bronze_1'); // Changed to instance ID
+      expect(toPromote).toEqual([]);
+
+      // Clean up
+      for (const robot of robots) {
+        await prisma.robot.deleteMany({ where: { id: robot.id } });
+      }
+      await prisma.weaponInventory.deleteMany({ where: { userId: testUser.id } });
+    });
+
+    it('should use higher LP threshold for silver tier (50 LP for Silver→Gold)', async () => {
+      // Create 20 robots in silver league
+      const robots = [];
+      for (let i = 0; i < 20; i++) {
+        const weaponInv = await prisma.weaponInventory.create({
+          data: { userId: testUser.id, weaponId: practiceSword.id },
+        });
+
+        const robot = await prisma.robot.create({
+          data: {
+            userId: testUser.id,
+            name: `Silver Threshold Robot ${i}`,
+            leagueId: 'silver_1',
+            currentLeague: 'silver',
+            currentHP: 10,
+            maxHP: 10,
+            currentShield: 2,
+            maxShield: 2,
+            elo: 1200,
+            // LP: 0, 5, 10, ..., 95. Only robots with ≥50 LP should be promotion candidates
+            // That's robots 10-19 (50, 55, 60, ..., 95) = 10 robots meet threshold
+            leaguePoints: i * 5,
+            totalBattles: 10,
+            cyclesInCurrentLeague: 10,
+            loadoutType: 'single',
+            mainWeaponId: weaponInv.id,
+          },
+        });
+        robots.push(robot);
+      }
+
+      const toPromote = await determinePromotions('silver_1');
+
+      // Top 10% of 20 eligible = 2 slots, but only robots with ≥50 LP qualify (silver threshold)
+      // Robots 10-19 have ≥50 LP, top 2 are robots 19 (95) and 18 (90)
+      expect(toPromote.length).toBe(2);
+      expect(toPromote[0].leaguePoints).toBeGreaterThanOrEqual(50);
+      expect(toPromote[1].leaguePoints).toBeGreaterThanOrEqual(50);
+
+      // Clean up
+      for (const robot of robots) {
+        await prisma.robot.deleteMany({ where: { id: robot.id } });
+      }
+      await prisma.weaponInventory.deleteMany({ where: { userId: testUser.id } });
+    });
+
+    it('should not promote silver robots with 25-49 LP (below silver threshold)', async () => {
+      // Create 20 robots in silver league, all with LP between 25-49
+      const robots = [];
+      for (let i = 0; i < 20; i++) {
+        const weaponInv = await prisma.weaponInventory.create({
+          data: { userId: testUser.id, weaponId: practiceSword.id },
+        });
+
+        const robot = await prisma.robot.create({
+          data: {
+            userId: testUser.id,
+            name: `Silver Below Threshold ${i}`,
+            leagueId: 'silver_1',
+            currentLeague: 'silver',
+            currentHP: 10,
+            maxHP: 10,
+            currentShield: 2,
+            maxShield: 2,
+            elo: 1200,
+            leaguePoints: 25 + i, // 25-44, all below silver threshold of 50
+            totalBattles: 10,
+            cyclesInCurrentLeague: 10,
+            loadoutType: 'single',
+            mainWeaponId: weaponInv.id,
+          },
+        });
+        robots.push(robot);
+      }
+
+      const toPromote = await determinePromotions('silver_1');
+
+      // No robots meet the 50 LP threshold for silver, so no promotions
       expect(toPromote).toEqual([]);
 
       // Clean up
@@ -542,6 +630,21 @@ describe('League Rebalancing Service', () => {
         await prisma.robot.deleteMany({ where: { id: robot.id } });
       }
       await prisma.weaponInventory.deleteMany({ where: { userId: testUser.id } });
+    });
+  });
+
+  describe('getMinLPForPromotion', () => {
+    it('should return correct per-tier LP thresholds', () => {
+      expect(getMinLPForPromotion('bronze')).toBe(25);
+      expect(getMinLPForPromotion('silver')).toBe(50);
+      expect(getMinLPForPromotion('gold')).toBe(75);
+      expect(getMinLPForPromotion('platinum')).toBe(100);
+      expect(getMinLPForPromotion('diamond')).toBe(125);
+      expect(getMinLPForPromotion('champion')).toBe(Infinity);
+    });
+
+    it('should return 25 as default for unknown tiers', () => {
+      expect(getMinLPForPromotion('unknown')).toBe(25);
     });
   });
 });

--- a/app/backend/tests/leagueRebalancingService.test.ts
+++ b/app/backend/tests/leagueRebalancingService.test.ts
@@ -243,12 +243,6 @@ describe('League Rebalancing Service', () => {
       expect(toPromote.length).toBe(2);
       expect(toPromote[0].leaguePoints).toBeGreaterThanOrEqual(50);
       expect(toPromote[1].leaguePoints).toBeGreaterThanOrEqual(50);
-
-      // Clean up
-      for (const robot of robots) {
-        await prisma.robot.deleteMany({ where: { id: robot.id } });
-      }
-      await prisma.weaponInventory.deleteMany({ where: { userId: testUser.id } });
     });
 
     it('should not promote silver robots with 25-49 LP (below silver threshold)', async () => {
@@ -284,12 +278,6 @@ describe('League Rebalancing Service', () => {
 
       // No robots meet the 50 LP threshold for silver, so no promotions
       expect(toPromote).toEqual([]);
-
-      // Clean up
-      for (const robot of robots) {
-        await prisma.robot.deleteMany({ where: { id: robot.id } });
-      }
-      await prisma.weaponInventory.deleteMany({ where: { userId: testUser.id } });
     });
 
     it('should return empty array when too few robots', async () => {

--- a/app/frontend/src/pages/HallOfRecordsPage.tsx
+++ b/app/frontend/src/pages/HallOfRecordsPage.tsx
@@ -100,9 +100,7 @@ function HallOfRecordsPage() {
               onClick={() => setActiveCategory(category.key)}
               className={`px-6 py-3 rounded-lg font-medium whitespace-nowrap transition-colors ${
                 activeCategory === category.key
-                  ? category.key === 'koth'
-                    ? 'bg-orange-500 text-gray-900'
-                    : 'bg-yellow-500 text-gray-900'
+                  ? 'bg-yellow-500 text-gray-900'
                   : 'bg-surface text-secondary hover:bg-surface-elevated'
               }`}
             >

--- a/docs/game-systems/GAME_DESIGN.md
+++ b/docs/game-systems/GAME_DESIGN.md
@@ -122,7 +122,7 @@ Configurable 0–50% HP threshold where the robot surrenders instead of fighting
 6-tier competitive ranking: Bronze → Silver → Gold → Platinum → Diamond → Champion
 
 - League points: +3 win, -1 loss, +1 draw
-- Top 10% per instance promoted (with ≥25 LP), bottom 10% demoted
+- Top 10% per instance promoted (with per-tier LP threshold: 25/50/75/100/125), bottom 10% demoted
 - LP carries over across promotions/demotions
 - Multiple instances per tier (max 100 robots each)
 - ELO rating (K=32) used for matchmaking, not combat

--- a/docs/game-systems/PRD_LEAGUE_SYSTEM.md
+++ b/docs/game-systems/PRD_LEAGUE_SYSTEM.md
@@ -4,11 +4,12 @@
 **Status**: ✅ Implemented  
 **Owner**: Robert Teunissen  
 **Epic**: League Progression System  
-**Version**: 2.0
+**Version**: 2.1
 
 ---
 
 ## Version History
+- v2.1 (April 18, 2026) — Per-tier LP promotion thresholds: Bronze 25, Silver 50, Gold 75, Platinum 100, Diamond 125. Replaces flat 25 LP threshold for all tiers.
 - v2.0 (April 2, 2026) — Consolidated from three separate documents (`LEAGUE_SYSTEM_IMPLEMENTATION_GUIDE.md`, `PRD_LEAGUE_PROMOTION.md`, `PRD_LEAGUE_REBALANCING.md`) and the LP matchmaking addendum (`PRD_MATCHMAKING_LP_UPDATE.md`). Removed proposed-but-not-implemented features (PromotionHistory model, Team2v2 model, instance change tracking, UI mockups for non-existent pages). Updated file paths to reflect backend service consolidation.
 - v1.1 (February 22, 2026) — Documentation corrections to match implementation
 - v1.0 (February 10, 2026) — Initial drafts of promotion and rebalancing PRDs
@@ -52,8 +53,18 @@ ELO (K=32, starting 1200) is used for matchmaking quality and seeding, not for p
 ### Promotion Requirements (all three must be met)
 
 1. Top 10% of robots within the specific instance (not the entire tier)
-2. ≥25 League Points
+2. League Points at or above the per-tier threshold (see table below)
 3. ≥5 cycles in current tier
+
+#### Per-Tier LP Thresholds
+
+| Current Tier | Promotion To | LP Required |
+|---|---|---|
+| Bronze | Silver | ≥25 |
+| Silver | Gold | ≥50 |
+| Gold | Platinum | ≥75 |
+| Platinum | Diamond | ≥100 |
+| Diamond | Champion | ≥125 |
 
 ### Demotion Requirements (both must be met)
 
@@ -131,7 +142,14 @@ Rebalancing is checked after each promotion/demotion cycle. The cycle scheduler 
 ### Promotion/Demotion (`services/league/leagueRebalancingService.ts`)
 
 ```typescript
-const MIN_LEAGUE_POINTS_FOR_PROMOTION = 25;
+const PROMOTION_LP_THRESHOLDS: Record<string, number> = {
+  bronze: 25,     // Bronze → Silver
+  silver: 50,     // Silver → Gold
+  gold: 75,       // Gold → Platinum
+  platinum: 100,  // Platinum → Diamond
+  diamond: 125,   // Diamond → Champion
+  champion: Infinity,
+};
 const PROMOTION_PERCENTAGE = 0.10;           // Top 10%
 const DEMOTION_PERCENTAGE = 0.10;            // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5;
@@ -177,7 +195,7 @@ All paths relative to `app/backend/src/`.
 
 ### Promotion/Demotion
 
-- Robot promoted with high LP (e.g., 45): Retains LP, but still needs 5 cycles before next promotion
+- Robot promoted with high LP (e.g., 45): Retains LP, but still needs 5 cycles before next promotion. Note: higher tiers require more LP (e.g., 50 for Silver→Gold)
 - Robot demoted with low LP (e.g., 2): Retains LP, lower tier competition should be easier
 - Yo-yo prevention: `cyclesInCurrentLeague` resets to 0 on any tier change, requiring 5 cycles before the next move
 - Champion tier: No promotions possible. Demotions still apply.
@@ -205,7 +223,6 @@ These are design ideas documented for future consideration:
 - Instance consolidation for underpopulated instances (<20 robots)
 - UI promotion zone indicators with LP progress bars
 - Promotion/demotion notifications
-- Dynamic LP thresholds based on tier difficulty
 
 ---
 

--- a/docs/game-systems/PRD_LEAGUE_SYSTEM.md
+++ b/docs/game-systems/PRD_LEAGUE_SYSTEM.md
@@ -1,6 +1,6 @@
 # Product Requirements Document: League System
 
-**Last Updated**: April 2, 2026  
+**Last Updated**: April 18, 2026  
 **Status**: ✅ Implemented  
 **Owner**: Robert Teunissen  
 **Epic**: League Progression System  


### PR DESCRIPTION
- Replace flat 25 LP promotion threshold with per-tier thresholds: Bronze→Silver 25, Silver→Gold 50, Gold→Platinum 75, Platinum→Diamond 100, Diamond→Champion 125
- Apply same fix to tag team league rebalancing service
- Add tests for per-tier thresholds (silver 50 LP gate, below-threshold rejection)
- Add unit tests for getMinLPForPromotion helper
- Fix KotH tab in Hall of Records using orange instead of yellow
- Update PRD, in-game guide, and spec docs to reflect new thresholds