### PR TITLE
fix: add --omit=dev to VPS deploy to prevent timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -392,7 +392,7 @@ jobs:
           command_timeout: 20m
           script: |
             cd /opt/armouredsouls/backend
-            npm install --prefer-offline
+            npm install --prefer-offline --omit=dev
             npx prisma generate
             npm run build
 
@@ -638,7 +638,7 @@ jobs:
           command_timeout: 20m
           script: |
             cd /opt/armouredsouls/backend
-            npm install --prefer-offline
+            npm install --prefer-offline --omit=dev
             npx prisma generate
             npm run build
 


### PR DESCRIPTION
The gitnexus devDependency has heavy native tree-sitter bindings that cause npm install to timeout (20min) on the 2GB VPS. Production/ACC deployments don't need devDependencies.

This fixes the Deploy to Acceptance failure in https://github.com/RobertTeunissen/ArmouredSouls/actions/runs/25100387273