### PR TITLE
Fix league standings eligibility display and add cohort promotion

### DIFF
--- a/app/backend/src/routes/leagues.ts
+++ b/app/backend/src/routes/leagues.ts
@@ -64,8 +64,6 @@ router.get('/:tier/standings', validateRequest({ params: leagueTierParamsSchema 
   });
 
   // Calculate promotion/demotion zone metadata
-  // Zone indicators are only meaningful when viewing a single instance,
-  // because the rebalancer evaluates promotion/demotion per-instance.
   const minLP = getMinLPForPromotion(tier);
   const isChampion = tier === 'champion';
   const isBronze = tier === 'bronze';
@@ -128,6 +126,17 @@ router.get('/:tier/standings', validateRequest({ params: leagueTierParamsSchema 
       });
       promotionRobotIds = new Set(promotionRobots.map(r => r.id));
     }
+  } else {
+    // Tier-wide eligible count (no per-robot zone highlighting without a specific instance)
+    eligibleCount = await prisma.robot.count({
+      where: {
+        leagueId: { in: leagueIds },
+        cyclesInCurrentLeague: { gte: MIN_CYCLES_IN_LEAGUE },
+        NOT: { name: 'Bye Robot' },
+      },
+    });
+
+    hasEnoughRobots = eligibleCount >= MIN_ROBOTS_FOR_REBALANCING;
   }
 
   const standings = robots.map((robot) => ({
@@ -144,6 +153,7 @@ router.get('/:tier/standings', validateRequest({ params: leagueTierParamsSchema 
     fame: robot.fame,
     userId: robot.user.id,
     cyclesInCurrentLeague: robot.cyclesInCurrentLeague,
+    eligible: robot.cyclesInCurrentLeague >= MIN_CYCLES_IN_LEAGUE,
     user: {
       username: robot.user.username,
       stableName: robot.user.stableName,

--- a/app/backend/src/services/league/leagueRebalancingService.ts
+++ b/app/backend/src/services/league/leagueRebalancingService.ts
@@ -23,6 +23,9 @@ const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_ROBOTS_FOR_REBALANCING = 10;
 
+// Minimum cohort size to open a new (empty) tier
+const MIN_COHORT_FOR_NEW_TIER = 3;
+
 // Re-export for consumers that need the helper
 export { getMinLPForPromotion } from './leaguePromotionThresholds';
 
@@ -302,7 +305,10 @@ async function rebalanceTier(tier: LeagueTier, excludeRobotIds: Set<number>): Pr
   
   logger.info(`[Rebalancing] ${tier}: ${totalInTier} total robots across ${instances.length} instances`);
 
-  // Process each instance separately
+  // Collect all promotion and demotion candidates across instances
+  const allPromotionCandidates: Robot[] = [];
+  const allDemotionCandidates: Robot[] = [];
+
   for (const instance of instances) {
     logger.info(`[Rebalancing] Processing ${instance.leagueId}...`);
     
@@ -328,30 +334,53 @@ async function rebalanceTier(tier: LeagueTier, excludeRobotIds: Set<number>): Pr
 
     // Determine promotions for this instance
     const toPromote = await determinePromotions(instance.leagueId, excludeRobotIds);
+    allPromotionCandidates.push(...toPromote);
     
     // Determine demotions for this instance
     const toDemote = await determineDemotions(instance.leagueId, excludeRobotIds);
+    allDemotionCandidates.push(...toDemote);
+  }
 
-    // Execute promotions
-    for (const robot of toPromote) {
+  // Check if destination tier needs a minimum cohort before promoting
+  const nextTier = getNextTierUp(tier);
+  let promotionsBlocked = false;
+
+  if (nextTier && allPromotionCandidates.length > 0) {
+    const robotsInDestinationTier = await prisma.robot.count({
+      where: {
+        currentLeague: nextTier,
+        NOT: { name: 'Bye Robot' },
+      },
+    });
+
+    if (robotsInDestinationTier === 0 && allPromotionCandidates.length < MIN_COHORT_FOR_NEW_TIER) {
+      // Destination tier is empty and we don't have enough to form a cohort — hold promotions
+      logger.info(`[Rebalancing] ${tier}: Holding promotions — destination ${nextTier} is empty, need ${MIN_COHORT_FOR_NEW_TIER} candidates but only have ${allPromotionCandidates.length}`);
+      promotionsBlocked = true;
+    }
+  }
+
+  // Execute promotions (unless blocked by cohort requirement)
+  if (!promotionsBlocked) {
+    for (const robot of allPromotionCandidates) {
       try {
         await promoteRobot(robot);
-        excludeRobotIds.add(robot.id); // Mark as processed
+        excludeRobotIds.add(robot.id);
         summary.promoted++;
       } catch (error) {
         logger.error(`[Rebalancing] Error promoting robot ${robot.id}:`, error);
       }
     }
+  }
 
-    // Execute demotions
-    for (const robot of toDemote) {
-      try {
-        await demoteRobot(robot);
-        excludeRobotIds.add(robot.id); // Mark as processed
-        summary.demoted++;
-      } catch (error) {
-        logger.error(`[Rebalancing] Error demoting robot ${robot.id}:`, error);
-      }
+  // Execute demotions (always — not affected by cohort logic)
+  for (const robot of allDemotionCandidates) {
+    try {
+      await demoteRobot(robot);
+      excludeRobotIds.add(robot.id);
+      summary.demoted++;
+    } catch (error) {
+      logger.error(`[Rebalancing] Error demoting robot ${robot.id}:`, error);
     }
   }
 

--- a/app/backend/src/services/league/leagueRebalancingService.ts
+++ b/app/backend/src/services/league/leagueRebalancingService.ts
@@ -374,7 +374,9 @@ async function rebalanceTier(tier: LeagueTier, excludeRobotIds: Set<number>): Pr
   }
 
   // Execute demotions (always — not affected by cohort logic)
+  // Filter out any robots that were just promoted (edge case prevention)
   for (const robot of allDemotionCandidates) {
+    if (excludeRobotIds.has(robot.id)) continue;
     try {
       await demoteRobot(robot);
       excludeRobotIds.add(robot.id);

--- a/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
+++ b/app/backend/src/services/tag-team/tagTeamLeagueRebalancingService.ts
@@ -21,6 +21,9 @@ const DEMOTION_PERCENTAGE = 0.10; // Bottom 10%
 const MIN_CYCLES_IN_LEAGUE_FOR_REBALANCING = 5; // Must be in current league for 5+ cycles
 const MIN_TEAMS_FOR_REBALANCING = 10;
 
+// Minimum cohort size to open a new (empty) tier
+const MIN_COHORT_FOR_NEW_TIER = 3;
+
 // Re-export for consumers that need the helper
 export { getMinLPForPromotion } from '../league/leaguePromotionThresholds';
 
@@ -327,7 +330,10 @@ async function rebalanceTier(
   
   logger.info(`[TagTeamRebalancing] ${tier}: ${totalInTier} total teams across ${instanceIds.length} instances`);
 
-  // Process each instance separately
+  // Collect all promotion and demotion candidates across instances
+  const allPromotionCandidates: TagTeam[] = [];
+  const allDemotionCandidates: TagTeam[] = [];
+
   for (const instanceId of instanceIds) {
     logger.info(`[TagTeamRebalancing] Processing ${instanceId}...`);
     
@@ -352,30 +358,51 @@ async function rebalanceTier(
 
     // Determine promotions for this instance
     const toPromote = await determinePromotions(instanceId, excludeTeamIds);
+    allPromotionCandidates.push(...toPromote);
 
     // Determine demotions for this instance
     const toDemote = await determineDemotions(instanceId, excludeTeamIds);
+    allDemotionCandidates.push(...toDemote);
+  }
 
-    // Execute promotions
-    for (const team of toPromote) {
+  // Check if destination tier needs a minimum cohort before promoting
+  const nextTier = getNextTierUp(tier);
+  let promotionsBlocked = false;
+
+  if (nextTier && allPromotionCandidates.length > 0) {
+    const teamsInDestinationTier = await prisma.tagTeam.count({
+      where: { tagTeamLeague: nextTier },
+    });
+
+    if (teamsInDestinationTier === 0 && allPromotionCandidates.length < MIN_COHORT_FOR_NEW_TIER) {
+      logger.info(`[TagTeamRebalancing] ${tier}: Holding promotions — destination ${nextTier} is empty, need ${MIN_COHORT_FOR_NEW_TIER} candidates but only have ${allPromotionCandidates.length}`);
+      promotionsBlocked = true;
+    }
+  }
+
+  // Execute promotions (unless blocked by cohort requirement)
+  if (!promotionsBlocked) {
+    for (const team of allPromotionCandidates) {
       try {
         await promoteTeam(team);
-        excludeTeamIds.add(team.id); // Mark as processed
+        excludeTeamIds.add(team.id);
         summary.promoted++;
       } catch (error) {
         logger.error(`[TagTeamRebalancing] Error promoting team ${team.id}:`, error);
       }
     }
+  }
 
-    // Execute demotions
-    for (const team of toDemote) {
-      try {
-        await demoteTeam(team);
-        excludeTeamIds.add(team.id); // Mark as processed
-        summary.demoted++;
-      } catch (error) {
-        logger.error(`[TagTeamRebalancing] Error demoting team ${team.id}:`, error);
-      }
+  // Execute demotions (always — not affected by cohort logic)
+  // Filter out any teams that were just promoted (edge case prevention)
+  for (const team of allDemotionCandidates) {
+    if (excludeTeamIds.has(team.id)) continue;
+    try {
+      await demoteTeam(team);
+      excludeTeamIds.add(team.id);
+      summary.demoted++;
+    } catch (error) {
+      logger.error(`[TagTeamRebalancing] Error demoting team ${team.id}:`, error);
     }
   }
 

--- a/app/frontend/src/pages/LeagueStandingsPage.tsx
+++ b/app/frontend/src/pages/LeagueStandingsPage.tsx
@@ -242,6 +242,10 @@ function LeagueStandingsPage() {
                   <span className="w-3 h-3 rounded-sm bg-red-500 inline-block"></span>
                   <span className="text-secondary">Demotion zone (bottom 10%, ≥{zoneMeta.minCycles} cycles)</span>
                 </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-3 h-3 rounded-sm bg-white/30 inline-block"></span>
+                  <span className="text-secondary">Faded = not yet eligible (&lt;{zoneMeta.minCycles} cycles)</span>
+                </div>
                 {!zoneMeta.hasEnoughRobots && (
                   <div className="flex items-center gap-2 text-warning">
                     <span>⚠️</span>
@@ -287,10 +291,12 @@ function LeagueStandingsPage() {
                           ? 'border-l-4 border-l-red-500 bg-red-900/10'
                           : '';
 
+                      const eligibilityClass = !robot.eligible ? 'opacity-50' : '';
+
                       return (
                         <tr
                           key={robot.id}
-                          className={`border-b border-white/10 ${zoneClass} ${
+                          className={`border-b border-white/10 ${zoneClass} ${eligibilityClass} ${
                             isMyBot ? 'bg-blue-900 bg-opacity-30' : 'hover:bg-surface-elevated'
                           } transition-colors`}
                         >

--- a/app/frontend/src/utils/matchmakingApi.ts
+++ b/app/frontend/src/utils/matchmakingApi.ts
@@ -179,6 +179,7 @@ export interface LeagueRobot {
   fame: number;
   userId: number;
   cyclesInCurrentLeague: number;
+  eligible: boolean;
   user: {
     username: string;
     stableName: string | null;


### PR DESCRIPTION
- Fix zone metadata showing 0 eligible robots when no instance selected (now calculates tier-wide eligible count in that case)
- Add 'eligible' field to standings response and dim ineligible robots in the frontend (opacity 50%) with legend explanation
- Add cohort promotion: don't promote into an empty tier until at least 3 robots qualify simultaneously, preventing solo robots in new tiers
- Demotions unaffected by cohort logic (always execute normally)