### PR TITLE
Perf/query optimization and security hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -312,6 +312,11 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.ACC_VPS_IP }} >> ~/.ssh/known_hosts
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
       - name: Transfer backend artifacts via rsync
         run: |
           rsync -avz --delete \
@@ -383,18 +388,33 @@ jobs:
               echo "Caddyfile unchanged — skipping reload"
             fi
 
-      - name: Install dependencies and build on VPS
+      - name: Build backend on CI runner
+        working-directory: ./app/backend
+        run: |
+          npm ci
+          npx prisma generate
+          npm run build
+        env:
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+
+      - name: Transfer backend dist to VPS
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            ./app/backend/dist/ \
+            ${{ secrets.ACC_VPS_USER }}@${{ secrets.ACC_VPS_IP }}:/opt/armouredsouls/backend/dist/
+
+      - name: Install dependencies on VPS
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.ACC_VPS_IP }}
           username: ${{ secrets.ACC_VPS_USER }}
           key: ${{ secrets.ACC_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 10m
           script: |
             cd /opt/armouredsouls/backend
             npm install --prefer-offline
             npx prisma generate
-            npm run build
 
       - name: Create pre-migration database backup
         uses: appleboy/ssh-action@v1
@@ -643,18 +663,33 @@ jobs:
               echo "Caddyfile unchanged — skipping reload"
             fi
 
-      - name: Install dependencies and build on VPS
+      - name: Build backend on CI runner
+        working-directory: ./app/backend
+        run: |
+          npm ci
+          npx prisma generate
+          npm run build
+        env:
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+
+      - name: Transfer backend dist to VPS
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            ./app/backend/dist/ \
+            ${{ secrets.PRD_VPS_USER }}@${{ secrets.PRD_VPS_IP }}:/opt/armouredsouls/backend/dist/
+
+      - name: Install dependencies on VPS
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.PRD_VPS_IP }}
           username: ${{ secrets.PRD_VPS_USER }}
           key: ${{ secrets.PRD_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 10m
           script: |
             cd /opt/armouredsouls/backend
             npm install --prefer-offline
             npx prisma generate
-            npm run build
 
       - name: Create pre-migration database backup
         uses: appleboy/ssh-action@v1

--- a/.kiro/steering/environments-and-deployment.md
+++ b/.kiro/steering/environments-and-deployment.md
@@ -200,6 +200,30 @@ Same as ACC but with:
 - `CORS_ORIGIN=https://armouredsouls.com,https://www.armouredsouls.com`
 - `LOG_LEVEL=warn`
 
+## Cycle Architecture (Important)
+
+The game does NOT run "complete cycles" as a single monolithic operation. Instead, the scheduler fires **separate cron jobs** at different times throughout the day:
+
+| Job | Schedule (UTC) | What it does |
+|-----|---------------|--------------|
+| League | 8 PM | Matchmaking → Battle execution → League rebalancing |
+| Tournament | 8 AM | Tournament bracket advancement |
+| Tag Team | 12 PM | Tag team matchmaking → battles → rebalancing |
+| KotH | Mon/Wed/Fri | KotH matchmaking → battles |
+| Settlement | 11 PM | Passive income → Operating costs → Cycle counter increment → Snapshot |
+
+Each job runs independently. They do NOT share a transaction or execution context. When optimizing or debugging cycle-related code, always consider which specific job is involved — not "the cycle" as a whole.
+
+The admin "bulk cycles" endpoint (`POST /api/admin/cycles/bulk`) is the only place that runs all jobs sequentially in a single call, and it's used exclusively for local development and seeding.
+
+## CI/CD & Tooling Notes
+
+- The agent has `gh` CLI access and is authenticated with GitHub. Use `gh` for viewing action logs, creating PRs, etc.
+- Always push to a new branch, never directly to main.
+- Use `gh run view <run-id> --log-failed` to inspect CI failures.
+- The E2E tests use Playwright with `continue-on-error: true` — they don't block the deploy, but failures should still be investigated.
+- The deploy to ACC is triggered automatically on push to `main` and depends on `backend-unit-tests`, `backend-integration-tests`, and `frontend-build` (NOT on E2E).
+
 ## VPS Architecture
 
 ### Scaleway DEV1-S Specs

--- a/app/backend/src/routes/auth.ts
+++ b/app/backend/src/routes/auth.ts
@@ -235,13 +235,36 @@ router.post('/login', validateRequest({ body: loginBodySchema }), async (req: Re
 /**
  * POST /api/auth/logout
  *
- * Logs the user out. Token invalidation is handled client-side (token removal).
- * This endpoint exists as a conventional hook for future server-side session cleanup.
+ * Logs the user out by incrementing tokenVersion, which invalidates all
+ * existing JWT tokens for this user on subsequent requests.
+ * Best-effort: returns 200 even if no valid token is provided.
  *
  * **Responses:**
  * - `200 OK` — `{ message: "Logged out successfully" }`
  */
-router.post('/logout', validateRequest({}), (req: Request, res: Response) => {
+router.post('/logout', validateRequest({}), async (req: Request, res: Response) => {
+  // Best-effort server-side invalidation: if a valid token is present, bump tokenVersion
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (token) {
+    try {
+      const jwtSecret = (await import('../config/env')).getConfig().jwtSecret;
+      const jwt = (await import('jsonwebtoken')).default;
+      const decoded = jwt.verify(token, jwtSecret) as { userId: string | number };
+      const userId = typeof decoded.userId === 'string' ? parseInt(decoded.userId, 10) : decoded.userId;
+
+      if (userId) {
+        await prisma.user.update({
+          where: { id: userId },
+          data: { tokenVersion: { increment: 1 } },
+        });
+      }
+    } catch {
+      // Token invalid or expired — no-op, user is effectively logged out already
+    }
+  }
+
   res.json({ message: 'Logged out successfully' });
 });
 

--- a/app/backend/src/routes/onboarding.ts
+++ b/app/backend/src/routes/onboarding.ts
@@ -432,7 +432,7 @@ router.post('/reset-account', authenticateToken, resetLimiter, validateRequest({
  *
  * Requirements: 14.4-14.8
  */
-router.get('/reset-eligibility', authenticateToken, resetLimiter, validateRequest({}), async (req: AuthRequest, res: Response) => {
+router.get('/reset-eligibility', authenticateToken, validateRequest({}), async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.user!.userId;
 

--- a/app/backend/src/services/achievement/achievementService.ts
+++ b/app/backend/src/services/achievement/achievementService.ts
@@ -225,6 +225,14 @@ class AchievementService implements IAchievementService {
         return [];
       }
 
+      // Pre-fetch robot and user data once to avoid repeated DB queries in evaluators.
+      // The robot record contains all stat fields needed by checkRobotStat triggers.
+      // The user record contains prestige, currency, and other user-level stats.
+      const [cachedRobot, cachedUser] = await Promise.all([
+        robotId ? prisma.robot.findUnique({ where: { id: robotId } }) : Promise.resolve(null),
+        prisma.user.findUnique({ where: { id: userId } }),
+      ]);
+
       // Evaluate each candidate
       const newlyUnlocked: UnlockedAchievement[] = [];
 
@@ -234,6 +242,8 @@ class AchievementService implements IAchievementService {
           userId,
           robotId,
           event,
+          cachedRobot,
+          cachedUser,
         );
 
         if (conditionMet) {
@@ -329,48 +339,50 @@ class AchievementService implements IAchievementService {
     userId: number,
     robotId: number | null,
     event: AchievementEvent,
+    cachedRobot: Record<string, unknown> | null,
+    cachedUser: Record<string, unknown> | null,
   ): Promise<boolean> {
     const { triggerType, triggerThreshold, triggerMeta } = achievement;
     const data = event.data;
 
     switch (triggerType) {
-      // ── Cumulative Robot Stats (from DB) ───────────────────────
+      // ── Cumulative Robot Stats (from cached robot) ─────────────
       case 'wins':
-        return this.checkRobotStat(robotId, 'wins', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'wins', triggerThreshold);
 
       case 'losses':
-        return this.checkRobotStat(robotId, 'losses', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'losses', triggerThreshold);
 
       case 'battles':
-        return this.checkRobotStat(robotId, 'totalBattles', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'totalBattles', triggerThreshold);
 
       case 'kills':
-        return this.checkRobotStat(robotId, 'kills', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'kills', triggerThreshold);
 
       case 'elo':
-        return this.checkRobotStat(robotId, 'elo', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'elo', triggerThreshold);
 
       case 'fame':
-        return this.checkRobotStat(robotId, 'fame', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'fame', triggerThreshold);
 
       case 'win_streak':
-        return this.checkRobotStat(robotId, 'currentWinStreak', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'currentWinStreak', triggerThreshold);
 
       case 'lose_streak':
-        return this.checkRobotStat(robotId, 'currentLoseStreak', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'currentLoseStreak', triggerThreshold);
 
       case 'koth_wins':
-        return this.checkRobotStat(robotId, 'kothWins', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'kothWins', triggerThreshold);
 
       case 'tag_team_wins':
-        return this.checkRobotStat(robotId, 'totalTagTeamWins', triggerThreshold);
+        return this.checkRobotStatCached(cachedRobot, 'totalTagTeamWins', triggerThreshold);
 
-      // ── Cumulative User Stats (from DB) ────────────────────────
+      // ── Cumulative User Stats (from cached user) ───────────────
       case 'prestige':
-        return this.checkUserStat(userId, 'prestige', triggerThreshold);
+        return this.checkUserStatCached(cachedUser, 'prestige', triggerThreshold);
 
       case 'currency':
-        return this.checkUserStat(userId, 'currency', triggerThreshold);
+        return this.checkUserStatCached(cachedUser, 'currency', triggerThreshold);
 
       // ── Battle-Specific Boolean Triggers (from event.data) ─────
       case 'perfect_victory':
@@ -436,17 +448,17 @@ class AchievementService implements IAchievementService {
       case 'solo_carry':
         return Boolean(data.won) && Boolean(data.soloCarry);
 
-      // ── Loadout/Stance Win Counters (from DB) ─────────────────
+      // ── Loadout/Stance Win Counters (from cached robot) ────────
       case 'loadout_wins': {
-        if (!robotId) return false;
+        if (!cachedRobot) return false;
         const loadoutType = String(triggerMeta?.loadoutType ?? 'dual_wield');
-        return this.checkLoadoutWins(robotId, loadoutType, triggerThreshold);
+        return this.checkLoadoutWinsCached(cachedRobot, loadoutType, triggerThreshold);
       }
 
       case 'stance_wins': {
-        if (!robotId) return false;
+        if (!cachedRobot) return false;
         const stance = String(triggerMeta?.stance ?? 'balanced');
-        return this.checkStanceWins(robotId, stance, triggerThreshold);
+        return this.checkStanceWinsCached(cachedRobot, stance, triggerThreshold);
       }
 
       // ── All Modes Win (DB query) ──────────────────────────────
@@ -455,16 +467,11 @@ class AchievementService implements IAchievementService {
 
       // ── League Promotion ──────────────────────────────────────
       case 'league_promotion': {
-        if (!robotId) return false;
+        if (!cachedRobot) return false;
         const targetLeague = String(triggerMeta?.league ?? '');
-        const robot = await prisma.robot.findUnique({
-          where: { id: robotId },
-          select: { currentLeague: true },
-        });
-        if (!robot) return false;
-        // Check if robot is at or above the target league tier
+        const currentLeague = String(cachedRobot.currentLeague ?? '');
         const tierOrder = ['bronze', 'silver', 'gold', 'platinum', 'diamond', 'champion'];
-        const currentIndex = tierOrder.indexOf(robot.currentLeague);
+        const currentIndex = tierOrder.indexOf(currentLeague);
         const targetIndex = tierOrder.indexOf(targetLeague);
         return currentIndex >= targetIndex && targetIndex >= 0;
       }
@@ -491,30 +498,15 @@ class AchievementService implements IAchievementService {
         return this.checkFacilityCount(userId, triggerThreshold, minLevel);
       }
 
-      // ── One-Time Triggers ─────────────────────────────────────
-      case 'onboarding': {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { hasCompletedOnboarding: true },
-        });
-        return user?.hasCompletedOnboarding === true;
-      }
+      // ── One-Time Triggers (from cached user) ──────────────────
+      case 'onboarding':
+        return (cachedUser as Record<string, unknown>)?.hasCompletedOnboarding === true;
 
-      case 'practice_battles': {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { totalPracticeBattles: true },
-        });
-        return (user?.totalPracticeBattles ?? 0) >= (triggerThreshold ?? 0);
-      }
+      case 'practice_battles':
+        return (Number((cachedUser as Record<string, unknown>)?.totalPracticeBattles ?? 0)) >= (triggerThreshold ?? 0);
 
-      case 'tournament_wins': {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { championshipTitles: true },
-        });
-        return (user?.championshipTitles ?? 0) >= (triggerThreshold ?? 0);
-      }
+      case 'tournament_wins':
+        return (Number((cachedUser as Record<string, unknown>)?.championshipTitles ?? 0)) >= (triggerThreshold ?? 0);
 
       // ── Tuning Triggers ───────────────────────────────────────
       case 'tuning_allocated':
@@ -533,13 +525,8 @@ class AchievementService implements IAchievementService {
         return true;
 
       // ── Financial Triggers (DB aggregates) ────────────────────
-      case 'bankrupt': {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { currency: true },
-        });
-        return (user?.currency ?? 0) < 0;
-      }
+      case 'bankrupt':
+        return (Number((cachedUser as Record<string, unknown>)?.currency ?? 0)) < 0;
 
       case 'lifetime_earnings':
         return this.checkLifetimeEarnings(userId, triggerThreshold);
@@ -557,6 +544,58 @@ class AchievementService implements IAchievementService {
 
 
   // ─── DB Query Helpers ────────────────────────────────────────────
+
+  /** Check a robot stat from the pre-fetched cached robot (no DB query). */
+  private checkRobotStatCached(
+    cachedRobot: Record<string, unknown> | null,
+    field: string,
+    threshold?: number,
+  ): boolean {
+    if (!cachedRobot || threshold === undefined) return false;
+    return Number(cachedRobot[field] ?? 0) >= threshold;
+  }
+
+  /** Check a user stat from the pre-fetched cached user (no DB query). */
+  private checkUserStatCached(
+    cachedUser: Record<string, unknown> | null,
+    field: string,
+    threshold?: number,
+  ): boolean {
+    if (!cachedUser || threshold === undefined) return false;
+    return Number(cachedUser[field] ?? 0) >= threshold;
+  }
+
+  /** Check loadout wins from cached robot (no DB query). */
+  private checkLoadoutWinsCached(
+    cachedRobot: Record<string, unknown>,
+    loadoutType: string,
+    threshold?: number,
+  ): boolean {
+    if (threshold === undefined) return false;
+    if (loadoutType === 'dual_wield') {
+      return Number(cachedRobot.dualWieldWins ?? 0) >= threshold;
+    }
+    return false;
+  }
+
+  /** Check stance wins from cached robot (no DB query). */
+  private checkStanceWinsCached(
+    cachedRobot: Record<string, unknown>,
+    stance: string,
+    threshold?: number,
+  ): boolean {
+    if (threshold === undefined) return false;
+    switch (stance) {
+      case 'offensive':
+        return Number(cachedRobot.offensiveWins ?? 0) >= threshold;
+      case 'defensive':
+        return Number(cachedRobot.defensiveWins ?? 0) >= threshold;
+      case 'balanced':
+        return Number(cachedRobot.balancedWins ?? 0) >= threshold;
+      default:
+        return false;
+    }
+  }
 
   private async checkRobotStat(
     robotId: number | null,

--- a/app/backend/src/services/admin/adminCycleService.ts
+++ b/app/backend/src/services/admin/adminCycleService.ts
@@ -46,7 +46,6 @@ export interface CycleResult {
   userGeneration?: unknown;
   matchmaking?: unknown;
   tagTeamMatchmaking?: unknown;
-  totalStreamingRevenue?: number;
   duration: number;
   error?: string;
 }
@@ -657,10 +656,6 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
       if (kothBattleSummary) {
         logger.info(`[Admin] KotH Battles: ${kothBattleSummary.totalMatches} (${kothBattleSummary.successfulMatches} successful, ${kothBattleSummary.failedMatches} failed)`);
       }
-      const totalStreamingRevenue = (battleSummary.totalStreamingRevenue || 0) + (tagTeamBattleSummary?.totalStreamingRevenue || 0);
-      if (totalStreamingRevenue > 0) {
-        logger.info(`[Admin] Streaming Revenue: ₡${totalStreamingRevenue.toLocaleString()}`);
-      }
       logger.info(`[Admin] ===================================`);
 
       cycleResults.push({
@@ -679,7 +674,6 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
         userGeneration: userGenerationSummary,
         matchmaking: matchmakingSummary,
         tagTeamMatchmaking: tagTeamMatchmakingSummary,
-        totalStreamingRevenue,
         duration: Date.now() - cycleStart,
       });
 

--- a/app/backend/src/services/admin/adminStatsService.ts
+++ b/app/backend/src/services/admin/adminStatsService.ts
@@ -218,34 +218,26 @@ export async function getSystemStats(userFilter: Prisma.UserWhereInput = {}) {
     },
   });
 
-  // Scheduled matches by type
-  const leagueMatchesScheduled = await prisma.scheduledLeagueMatch.count({
-    where: { status: 'scheduled' },
-  });
-  const leagueMatchesCompleted = await prisma.scheduledLeagueMatch.count({
-    where: { status: 'completed' },
-  });
-
-  const tournamentMatchesScheduled = await prisma.scheduledTournamentMatch.count({
-    where: { status: { in: ['pending', 'scheduled'] } },
-  });
-  const tournamentMatchesCompleted = await prisma.scheduledTournamentMatch.count({
-    where: { status: 'completed' },
-  });
-
-  const tagTeamMatchesScheduled = await prisma.scheduledTagTeamMatch.count({
-    where: { status: 'scheduled' },
-  });
-  const tagTeamMatchesCompleted = await prisma.scheduledTagTeamMatch.count({
-    where: { status: 'completed' },
-  });
-
-  const kothMatchesScheduled = await prisma.scheduledKothMatch.count({
-    where: { status: 'scheduled' },
-  });
-  const kothMatchesCompleted = await prisma.scheduledKothMatch.count({
-    where: { status: 'completed' },
-  });
+  // Scheduled matches by type (parallel queries)
+  const [
+    leagueMatchesScheduled,
+    leagueMatchesCompleted,
+    tournamentMatchesScheduled,
+    tournamentMatchesCompleted,
+    tagTeamMatchesScheduled,
+    tagTeamMatchesCompleted,
+    kothMatchesScheduled,
+    kothMatchesCompleted,
+  ] = await Promise.all([
+    prisma.scheduledLeagueMatch.count({ where: { status: 'scheduled' } }),
+    prisma.scheduledLeagueMatch.count({ where: { status: 'completed' } }),
+    prisma.scheduledTournamentMatch.count({ where: { status: { in: ['pending', 'scheduled'] } } }),
+    prisma.scheduledTournamentMatch.count({ where: { status: 'completed' } }),
+    prisma.scheduledTagTeamMatch.count({ where: { status: 'scheduled' } }),
+    prisma.scheduledTagTeamMatch.count({ where: { status: 'completed' } }),
+    prisma.scheduledKothMatch.count({ where: { status: 'scheduled' } }),
+    prisma.scheduledKothMatch.count({ where: { status: 'completed' } }),
+  ]);
 
   // Total scheduled/completed across all types
   const scheduledMatches =

--- a/app/backend/src/services/analytics/matchmakingService.ts
+++ b/app/backend/src/services/analytics/matchmakingService.ts
@@ -85,6 +85,54 @@ export function checkSchedulingReadiness(robot: Robot): BattleReadinessCheck {
 }
 
 /**
+ * Get recent opponents for multiple robots in a single query (batch version).
+ * Returns a map of robotId → array of recent opponent IDs.
+ *
+ * NOTE: Uses a global `take` limit which is an approximation — if one robot
+ * has many more recent battles than others, some robots may get incomplete
+ * opponent lists. This is an acceptable tradeoff for matchmaking quality vs
+ * query count (1 query instead of N). The soft deprioritization of recent
+ * opponents means an occasional repeat match is not game-breaking.
+ */
+async function getRecentOpponentsBatch(robotIds: number[], limit: number = RECENT_OPPONENT_LIMIT): Promise<Map<number, number[]>> {
+  if (robotIds.length === 0) return new Map();
+
+  // Single query to get recent battles for all robots in the set
+  const recentBattles = await prisma.battle.findMany({
+    where: {
+      OR: [
+        { robot1Id: { in: robotIds } },
+        { robot2Id: { in: robotIds } },
+      ],
+    },
+    orderBy: { createdAt: 'desc' },
+    // Fetch enough battles to cover all robots (worst case: each robot has `limit` unique battles)
+    take: robotIds.length * limit,
+    select: {
+      robot1Id: true,
+      robot2Id: true,
+    },
+  });
+
+  // Build per-robot opponent lists from the batch result
+  const map = new Map<number, number[]>();
+  for (const robotId of robotIds) {
+    const opponents: number[] = [];
+    for (const battle of recentBattles) {
+      if (opponents.length >= limit) break;
+      if (battle.robot1Id === robotId) {
+        opponents.push(battle.robot2Id);
+      } else if (battle.robot2Id === robotId) {
+        opponents.push(battle.robot1Id);
+      }
+    }
+    map.set(robotId, opponents);
+  }
+
+  return map;
+}
+
+/**
  * Get recent opponents for a robot (last N matches)
  */
 async function getRecentOpponents(robotId: number, limit: number = RECENT_OPPONENT_LIMIT): Promise<number[]> {
@@ -256,14 +304,8 @@ async function pairRobots(robots: Robot[]): Promise<MatchPair[]> {
   const matches: MatchPair[] = [];
   const availableRobots = [...robots]; // Copy array
   
-  // Pre-fetch recent opponents for all robots
-  const recentOpponentsMap = new Map<number, number[]>();
-  await Promise.all(
-    robots.map(async robot => {
-      const opponents = await getRecentOpponents(robot.id);
-      recentOpponentsMap.set(robot.id, opponents);
-    })
-  );
+  // Pre-fetch recent opponents for all robots in a single batch query
+  const recentOpponentsMap = await getRecentOpponentsBatch(robots.map(r => r.id));
   
   // Pair robots using greedy algorithm
   while (availableRobots.length > 1) {

--- a/app/backend/src/services/common/eventLogger.ts
+++ b/app/backend/src/services/common/eventLogger.ts
@@ -97,55 +97,36 @@ interface EventLogEntry {
 }
 
 /**
- * Sequence number cache per cycle
+ * Sequence number cache per cycle.
+ * Node.js is single-threaded — no lock needed for synchronous counter increments.
+ * The cache is only invalidated on unique constraint violations (rare race with
+ * parallel test runners or multi-process deployments).
  */
 const sequenceNumberCache = new Map<number, number>();
 
 /**
- * Locks for sequence number generation to prevent race conditions
- */
-const sequenceLocks = new Map<number, Promise<void>>();
-
-/**
- * Get the next sequence number for a cycle (thread-safe)
+ * Get the next sequence number for a cycle.
+ * Synchronous in-memory increment when cached; single DB query on cache miss.
  */
 async function getNextSequenceNumber(cycleNumber: number): Promise<number> {
-  // Wait for any pending lock on this cycle
-  while (sequenceLocks.has(cycleNumber)) {
-    await sequenceLocks.get(cycleNumber);
+  // Check cache first (fast path — no DB hit)
+  if (sequenceNumberCache.has(cycleNumber)) {
+    const current = sequenceNumberCache.get(cycleNumber)!;
+    const next = current + 1;
+    sequenceNumberCache.set(cycleNumber, next);
+    return next;
   }
-  
-  // Create a lock for this operation
-  let releaseLock: () => void;
-  const lockPromise = new Promise<void>((resolve) => {
-    releaseLock = resolve;
+
+  // Cache miss: query database for the highest sequence number in this cycle
+  const lastEvent = await prisma.auditLog.findFirst({
+    where: { cycleNumber },
+    orderBy: { sequenceNumber: 'desc' },
+    select: { sequenceNumber: true },
   });
-  sequenceLocks.set(cycleNumber, lockPromise);
-  
-  try {
-    // Check cache first
-    if (sequenceNumberCache.has(cycleNumber)) {
-      const current = sequenceNumberCache.get(cycleNumber)!;
-      const next = current + 1;
-      sequenceNumberCache.set(cycleNumber, next);
-      return next;
-    }
-    
-    // Query database for the highest sequence number in this cycle
-    const lastEvent = await prisma.auditLog.findFirst({
-      where: { cycleNumber },
-      orderBy: { sequenceNumber: 'desc' },
-      select: { sequenceNumber: true },
-    });
-    
-    const nextSequence = lastEvent ? lastEvent.sequenceNumber + 1 : 1;
-    sequenceNumberCache.set(cycleNumber, nextSequence);
-    return nextSequence;
-  } finally {
-    // Release the lock
-    sequenceLocks.delete(cycleNumber);
-    releaseLock!();
-  }
+
+  const nextSequence = lastEvent ? lastEvent.sequenceNumber + 1 : 1;
+  sequenceNumberCache.set(cycleNumber, nextSequence);
+  return nextSequence;
 }
 
 /**

--- a/app/backend/src/services/cycle/cycleScheduler.ts
+++ b/app/backend/src/services/cycle/cycleScheduler.ts
@@ -1,5 +1,6 @@
 import cron, { ScheduledTask } from 'node-cron';
 import logger from '../../config/logger';
+import { getNextCronOccurrence } from '../../utils/scheduleUtils';
 import { repairAllRobots } from '../economy/repairService';
 import { executeScheduledBattles } from '../league/leagueBattleOrchestrator';
 import { executeScheduledKothBattles } from '../koth/kothBattleOrchestrator';
@@ -18,7 +19,7 @@ import { runTagTeamMatchmaking } from '../tag-team/tagTeamMatchmakingService';
 import { runKothMatchmaking } from '../koth/kothMatchmakingService';
 import prisma from '../../lib/prisma';
 import { practiceArenaMetrics } from '../practice-arena/practiceArenaMetrics';
-import { EventLogger } from '../common/eventLogger';
+import { EventLogger, EventType } from '../common/eventLogger';
 import { JobContext } from '../notifications/integration';
 import { buildSuccessMessage, buildErrorMessage, getActiveIntegrations, dispatchNotification } from '../notifications/notification-service';
 
@@ -269,71 +270,101 @@ async function executeSettlement(): Promise<JobContext> {
 
   // Step 1: Calculate and credit passive income for all users
   logger.info('Daily Settlement: Step 1 — Processing passive income');
-  const { calculateDailyPassiveIncome, calculateFacilityOperatingCost } = await import('../../utils/economyCalculations');
+  const { calculateMerchandisingIncome, calculateFacilityOperatingCost } = await import('../../utils/economyCalculations');
 
   const allUsers = await prisma.user.findMany({
     where: { NOT: { username: 'bye_robot_user' } },
     select: { id: true, prestige: true },
   });
 
+  const userIds = allUsers.map(u => u.id);
+
+  // Batch-load all facilities and robots for all users (2 queries instead of 2N)
+  const [allFacilities, allRobots] = await Promise.all([
+    prisma.facility.findMany({ where: { userId: { in: userIds } } }),
+    prisma.robot.findMany({
+      where: { userId: { in: userIds } },
+      select: { id: true, userId: true, totalBattles: true, fame: true, name: true },
+    }),
+  ]);
+
+  // Group by userId in memory
+  const facilitiesByUser = new Map<number, typeof allFacilities>();
+  for (const f of allFacilities) {
+    if (!facilitiesByUser.has(f.userId)) facilitiesByUser.set(f.userId, []);
+    facilitiesByUser.get(f.userId)!.push(f);
+  }
+  const robotsByUser = new Map<number, typeof allRobots>();
+  for (const r of allRobots) {
+    if (!robotsByUser.has(r.userId)) robotsByUser.set(r.userId, []);
+    robotsByUser.get(r.userId)!.push(r);
+  }
+
   let totalPassiveIncome = 0;
   let totalOperatingCosts = 0;
 
-  for (const user of allUsers) {
-    const passiveIncome = await calculateDailyPassiveIncome(user.id);
+  // Collect audit events for batch insertion
+  const passiveIncomeEvents: Array<{
+    eventType: typeof import('../common/eventLogger').EventType.PASSIVE_INCOME;
+    payload: Record<string, unknown>;
+    userId: number;
+  }> = [];
 
-    if (passiveIncome.total > 0) {
-      const userRobots = await prisma.robot.findMany({
-        where: { userId: user.id },
-        select: { totalBattles: true, fame: true },
-      });
+  for (const user of allUsers) {
+    const userFacilities = facilitiesByUser.get(user.id) || [];
+    const merchHub = userFacilities.find(f => f.facilityType === 'merchandising_hub');
+    const merchLevel = merchHub?.level || 0;
+
+    const merchandising = calculateMerchandisingIncome(merchLevel, user.prestige);
+
+    if (merchandising > 0) {
+      const userRobots = robotsByUser.get(user.id) || [];
       const totalBattles = userRobots.reduce((sum, r) => sum + r.totalBattles, 0);
       const totalFame = userRobots.reduce((sum, r) => sum + r.fame, 0);
 
-      const incomeGenerator = await prisma.facility.findUnique({
-        where: {
-          userId_facilityType: {
-            userId: user.id,
-            facilityType: 'merchandising_hub',
-          },
+      passiveIncomeEvents.push({
+        eventType: EventType.PASSIVE_INCOME,
+        payload: {
+          merchandising,
+          streaming: 0,
+          totalIncome: merchandising,
+          facilityLevel: merchLevel,
+          prestige: user.prestige,
+          totalBattles,
+          totalFame,
         },
+        userId: user.id,
       });
-
-      await eventLogger.logPassiveIncome(
-        currentCycleNumber,
-        user.id,
-        passiveIncome.merchandising,
-        0,
-        incomeGenerator?.level || 0,
-        user.prestige,
-        totalBattles,
-        totalFame
-      );
 
       await prisma.user.update({
         where: { id: user.id },
-        data: { currency: { increment: passiveIncome.total } },
+        data: { currency: { increment: merchandising } },
       });
 
-      totalPassiveIncome += passiveIncome.total;
+      totalPassiveIncome += merchandising;
     }
+  }
+
+  // Batch-insert passive income audit events
+  if (passiveIncomeEvents.length > 0) {
+    await eventLogger.logEventBatch(currentCycleNumber, passiveIncomeEvents);
   }
   logger.info(`Daily Settlement: Passive income credited — ₡${totalPassiveIncome.toLocaleString()}`);
 
   // Step 2: Calculate and debit operating costs for all users
   logger.info('Daily Settlement: Step 2 — Processing operating costs');
 
+  const operatingCostEvents: Array<{
+    eventType: typeof import('../common/eventLogger').EventType.OPERATING_COSTS;
+    payload: Record<string, unknown>;
+    userId: number;
+  }> = [];
+
   for (const user of allUsers) {
-    const facilities = await prisma.facility.findMany({
-      where: { userId: user.id },
-    });
+    const userFacilities = facilitiesByUser.get(user.id) || [];
+    const userRobots = robotsByUser.get(user.id) || [];
 
-    const userRobots = await prisma.robot.findMany({
-      where: { userId: user.id },
-      select: { totalBattles: true, fame: true },
-    });
-
-    const facilityCosts = facilities.map(f => ({
+    const facilityCosts = userFacilities.map(f => ({
       facilityType: f.facilityType,
       level: f.level,
       cost: calculateFacilityOperatingCost(f.facilityType, f.level),
@@ -352,12 +383,14 @@ async function executeSettlement(): Promise<JobContext> {
     }
 
     if (totalCost > 0) {
-      await eventLogger.logOperatingCosts(
-        currentCycleNumber,
-        user.id,
-        facilityCosts.filter(f => f.cost > 0),
-        totalCost
-      );
+      operatingCostEvents.push({
+        eventType: EventType.OPERATING_COSTS,
+        payload: {
+          costs: facilityCosts.filter(f => f.cost > 0),
+          totalCost,
+        },
+        userId: user.id,
+      });
 
       await prisma.user.update({
         where: { id: user.id },
@@ -366,6 +399,11 @@ async function executeSettlement(): Promise<JobContext> {
 
       totalOperatingCosts += totalCost;
     }
+  }
+
+  // Batch-insert operating cost audit events
+  if (operatingCostEvents.length > 0) {
+    await eventLogger.logEventBatch(currentCycleNumber, operatingCostEvents);
   }
   logger.info(`Daily Settlement: Operating costs debited — ₡${totalOperatingCosts.toLocaleString()}`);
 
@@ -393,7 +431,7 @@ async function executeSettlement(): Promise<JobContext> {
     logger.error(`[Settlement] Bankrupt achievement check failed: ${err}`);
   }
 
-  // Step 3: Log end-of-cycle balances for all users
+  // Step 3: Log end-of-cycle balances for all users (batch insert)
   logger.info('Daily Settlement: Step 3 — Logging end-of-cycle balances');
   const endOfCycleUsers = await prisma.user.findMany({
     where: { NOT: { username: 'bye_robot_user' } },
@@ -401,15 +439,18 @@ async function executeSettlement(): Promise<JobContext> {
     orderBy: { id: 'asc' },
   });
 
-  for (const user of endOfCycleUsers) {
-    await eventLogger.logCycleEndBalance(
-      currentCycleNumber,
-      user.id,
-      user.username,
-      user.stableName,
-      user.currency
-    );
-  }
+  await eventLogger.logEventBatch(
+    currentCycleNumber,
+    endOfCycleUsers.map(user => ({
+      eventType: EventType.CYCLE_END_BALANCE,
+      payload: {
+        username: user.username,
+        stableName: user.stableName,
+        balance: user.currency,
+      },
+      userId: user.id,
+    })),
+  );
   logger.info(`Daily Settlement: Balances logged for ${endOfCycleUsers.length} users`);
 
   // Step 4: Increment cycle counters (cycleMetadata.totalCycles + 1, lastCycleAt, robot/tagTeam counters)
@@ -640,11 +681,17 @@ export function initScheduler(config: SchedulerConfig): void {
 // --- State query ---
 
 export function getSchedulerState(): SchedulerState {
+  // Compute nextRunAt dynamically from each job's cron schedule
+  const jobs = Array.from(jobStates.values()).map(job => ({
+    ...job,
+    nextRunAt: schedulerActive ? getNextCronOccurrence(job.schedule) : null,
+  }));
+
   return {
     active: schedulerActive,
     runningJob,
     queue: [...jobQueue],
-    jobs: Array.from(jobStates.values()),
+    jobs,
   };
 }
 

--- a/app/backend/src/services/economy/repairService.ts
+++ b/app/backend/src/services/economy/repairService.ts
@@ -62,34 +62,46 @@ export async function repairAllRobots(deductCosts: boolean = true, cycleNumber?:
     robotsByUser.get(robot.userId)!.push(robot);
   }
 
+  // Batch-load all facilities and robot counts for all affected users (2 queries instead of 2N)
+  const affectedUserIds = Array.from(robotsByUser.keys());
+  const [allFacilities, robotCounts] = await Promise.all([
+    prisma.facility.findMany({
+      where: {
+        userId: { in: affectedUserIds },
+        facilityType: { in: ['repair_bay', 'medical_bay'] },
+      },
+    }),
+    prisma.robot.groupBy({
+      by: ['userId'],
+      where: {
+        userId: { in: affectedUserIds },
+        NOT: { name: 'Bye Robot' },
+      },
+      _count: { id: true },
+    }),
+  ]);
+
+  // Build lookup maps
+  const facilitiesByUser = new Map<number, typeof allFacilities>();
+  for (const f of allFacilities) {
+    if (!facilitiesByUser.has(f.userId)) facilitiesByUser.set(f.userId, []);
+    facilitiesByUser.get(f.userId)!.push(f);
+  }
+  const robotCountByUser = new Map(robotCounts.map(r => [r.userId, r._count.id]));
+
   let totalBaseCost = 0;
   let totalFinalCost = 0;
   const userSummaries = [];
 
   for (const [userId, userRobots] of robotsByUser.entries()) {
-    // Get repair bay and medical bay facilities for discounts
-    const facilities = await prisma.facility.findMany({
-      where: {
-        userId,
-        facilityType: {
-          in: ['repair_bay', 'medical_bay'],
-        },
-      },
-    });
+    const facilities = facilitiesByUser.get(userId) || [];
 
     const repairBay = facilities.find(f => f.facilityType === 'repair_bay');
     const medicalBay = facilities.find(f => f.facilityType === 'medical_bay');
     
     const repairBayLevel = repairBay?.level || 0;
     const medicalBayLevel = medicalBay?.level || 0;
-    
-    // Query active robot count for multi-robot discount (exclude "Bye Robot")
-    const activeRobotCount = await prisma.robot.count({
-      where: {
-        userId,
-        NOT: { name: 'Bye Robot' }
-      }
-    });
+    const activeRobotCount = robotCountByUser.get(userId) || 0;
     
     // Calculate discount using new formula: repairBayLevel × (5 + activeRobotCount), capped at 90%
     const rawDiscount = repairBayLevel * (5 + activeRobotCount);
@@ -158,15 +170,7 @@ export async function repairAllRobots(deductCosts: boolean = true, cycleNumber?:
           'automatic'
         );
         
-        // Get user's stable name for logging
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { stableName: true },
-        });
-        const stableInfo = user?.stableName ? ` (${user.stableName})` : '';
-        
-        // Single consolidated log per robot
-        logger.info(`[RepairService] | User ${userId}${stableInfo} | Robot ${robot.id} (${robot.name}) | Cost: ₡${repairCost.toLocaleString()} | Discount: ${repairBayDiscount}%`);
+        logger.info(`[RepairService] | User ${userId} | Robot ${robot.id} (${robot.name}) | Cost: ₡${repairCost.toLocaleString()} | Discount: ${repairBayDiscount}%`);
       } catch (logError) {
         logger.error(`[RepairService] | ERROR | User ${userId} | Robot ${robot.id} | Failed to log repair event:`, logError instanceof Error ? logError.message : logError);
       }

--- a/app/backend/src/services/economy/spendingTracker.ts
+++ b/app/backend/src/services/economy/spendingTracker.ts
@@ -21,6 +21,7 @@ interface BudgetSpent {
 /**
  * Track spending for a user during onboarding.
  * Only tracks if user hasn't completed onboarding yet.
+ * Uses a conditional update to avoid a read query for users who've already completed onboarding.
  * 
  * @param userId - The user ID
  * @param category - The spending category
@@ -32,17 +33,17 @@ export async function trackSpending(
   amount: number
 ): Promise<void> {
   try {
-    // Get user's onboarding state
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
+    // Conditional read: only fetch if user hasn't completed onboarding
+    // This avoids a wasted query for the majority of users (post-onboarding)
+    const user = await prisma.user.findFirst({
+      where: { id: userId, hasCompletedOnboarding: false },
       select: {
-        hasCompletedOnboarding: true,
         onboardingChoices: true,
       },
     });
 
-    // Only track during onboarding
-    if (!user || user.hasCompletedOnboarding) {
+    // User has completed onboarding or doesn't exist — skip
+    if (!user) {
       return;
     }
 

--- a/app/backend/src/services/league/leagueBattleOrchestrator.ts
+++ b/app/backend/src/services/league/leagueBattleOrchestrator.ts
@@ -232,34 +232,15 @@ async function createBattleRecord(
   const baseWinRewardAmount = getLeagueWinReward(scheduledMatch.leagueType);
   const participationReward = getParticipationReward(scheduledMatch.leagueType);
   
-  // Get users for prestige multiplier
-  const robot1User = await prisma.user.findUnique({ where: { id: robot1.userId } });
-  const robot2User = await prisma.user.findUnique({ where: { id: robot2.userId } });
+  // Get users for prestige multiplier (parallel fetch)
+  const [robot1User, robot2User] = await Promise.all([
+    prisma.user.findUnique({ where: { id: robot1.userId }, select: { id: true, prestige: true } }),
+    prisma.user.findUnique({ where: { id: robot2.userId }, select: { id: true, prestige: true } }),
+  ]);
   
-  // Query facility levels and robot count for repair cost calculation
-  const robot1Facilities = await prisma.facility.findMany({
-    where: { userId: robot1.userId, facilityType: { in: ['Repair Bay', 'Medical Bay'] } }
-  });
-  const robot2Facilities = await prisma.facility.findMany({
-    where: { userId: robot2.userId, facilityType: { in: ['Repair Bay', 'Medical Bay'] } }
-  });
-  
-  const _robot1RepairBayLevel = robot1Facilities.find(f => f.facilityType === 'Repair Bay')?.level || 0;
-  const _robot1MedicalBayLevel = robot1Facilities.find(f => f.facilityType === 'Medical Bay')?.level || 0;
-  const _robot2RepairBayLevel = robot2Facilities.find(f => f.facilityType === 'Repair Bay')?.level || 0;
-  const _robot2MedicalBayLevel = robot2Facilities.find(f => f.facilityType === 'Medical Bay')?.level || 0;
-  
-  const _robot1ActiveRobotCount = await prisma.robot.count({
-    where: { userId: robot1.userId, NOT: { name: 'Bye Robot' } }
-  });
-  const _robot2ActiveRobotCount = await prisma.robot.count({
-    where: { userId: robot2.userId, NOT: { name: 'Bye Robot' } }
-  });
-  
-  // Calculate repair costs using canonical function
-  // NOTE: Repair costs are NOT calculated here anymore
-  // They are calculated by RepairService when repairs are actually triggered
-  // This ensures accurate costs based on current damage and facility levels
+  // NOTE: Repair costs are NOT calculated here anymore.
+  // They are calculated by RepairService when repairs are actually triggered.
+  // This ensures accurate costs based on current damage and facility levels.
   
   // Winner gets midpoint of league range + participation reward, with prestige bonus
   // Loser gets only participation reward
@@ -455,34 +436,17 @@ async function createBattleRecord(
 /**
  * Update robot stats after battle and award prestige/fame.
  * Uses shared updateRobotCombatStats + awardCreditsToUser + awardPrestigeToUser.
+ * Accepts pre-fetched participant data to avoid redundant DB queries.
  */
 async function updateRobotStats(
   robot: Robot,
   battle: Battle,
-  isRobot1: boolean,
+  participant: { finalHP: number; eloAfter: number; damageDealt: number; yielded: boolean; destroyed: boolean },
+  opponentParticipant: { damageDealt: number; destroyed: boolean } | null,
   isByeMatch: boolean
 ): Promise<{ prestigeAwarded: number; fameAwarded: number }> {
   const isWinner = battle.winnerId === robot.id;
   const isDraw = battle.winnerId === null;
-  
-  // Get participant data from BattleParticipant table
-  const participant = await prisma.battleParticipant.findUnique({
-    where: {
-      battleId_robotId: {
-        battleId: battle.id,
-        robotId: robot.id,
-      },
-    },
-  });
-  
-  if (!participant) {
-    throw new BattleError(
-      BattleErrorCode.INVALID_BATTLE_STATE,
-      `BattleParticipant not found for battle ${battle.id}, robot ${robot.id}`,
-      500,
-      { battleId: battle.id, robotId: robot.id }
-    );
-  }
   
   const finalHP = participant.finalHP;
   const newELO = participant.eloAfter;
@@ -505,17 +469,6 @@ async function updateRobotStats(
     prestigeAwarded = calculatePrestigeForBattle(robot, isDraw, isByeMatch);
     fameAwarded = calculateFameForBattle(robot, finalHP, isDraw, isByeMatch);
   }
-  
-  // Get opponent's participant data to check if destroyed
-  const opponentId = isRobot1 ? battle.robot2Id : battle.robot1Id;
-  const opponentParticipant = await prisma.battleParticipant.findUnique({
-    where: {
-      battleId_robotId: {
-        battleId: battle.id,
-        robotId: opponentId,
-      },
-    },
-  });
   
   // Update robot combat stats via shared helper
   await updateRobotCombatStats({
@@ -622,36 +575,12 @@ export async function processBattle(scheduledMatch: ScheduledLeagueMatch): Promi
   const battle = await createBattleRecord(scheduledMatch, robot1, robot2, result);
   result.battleId = battle.id;
   
-  // Update robot stats and award prestige/fame
-  const stats1 = await updateRobotStats(robot1, battle, true, isByeMatch);
-  const stats2 = await updateRobotStats(robot2, battle, false, isByeMatch);
-  
-  const totalPrestige = stats1.prestigeAwarded + stats2.prestigeAwarded;
-  const totalFame = stats1.fameAwarded + stats2.fameAwarded;
-  
-  // Calculate and award streaming revenue
-  let streamingRevenue1 = null;
-  let streamingRevenue2 = null;
-  
-  if (!isByeMatch) {
-    streamingRevenue1 = await awardStreamingRevenueForParticipant(robot1.id, robot1.userId, battle.id, false);
-    streamingRevenue2 = await awardStreamingRevenueForParticipant(robot2.id, robot2.userId, battle.id, false);
-    
-    if (streamingRevenue1) {
-      logger.info(`[Streaming] ${robot1.name} earned ₡${streamingRevenue1.totalRevenue.toLocaleString()} from Battle #${battle.id}`);
-    }
-    if (streamingRevenue2) {
-      logger.info(`[Streaming] ${robot2.name} earned ₡${streamingRevenue2.totalRevenue.toLocaleString()} from Battle #${battle.id}`);
-    }
-  }
-  
-  // Get participant data for audit logging
-  const robot1Participant = await prisma.battleParticipant.findUnique({
-    where: { battleId_robotId: { battleId: battle.id, robotId: robot1.id } },
+  // Fetch both participants once (created by createBattleRecord) — reused throughout
+  const participants = await prisma.battleParticipant.findMany({
+    where: { battleId: battle.id },
   });
-  const robot2Participant = await prisma.battleParticipant.findUnique({
-    where: { battleId_robotId: { battleId: battle.id, robotId: robot2.id } },
-  });
+  const robot1Participant = participants.find(p => p.robotId === robot1.id)!;
+  const robot2Participant = participants.find(p => p.robotId === robot2.id)!;
   
   if (!robot1Participant || !robot2Participant) {
     throw new BattleError(
@@ -662,54 +591,80 @@ export async function processBattle(scheduledMatch: ScheduledLeagueMatch): Promi
     );
   }
   
-  // Determine results for each robot
+  // Update robot stats and award prestige/fame (pass pre-fetched participants)
+  const stats1 = await updateRobotStats(robot1, battle, robot1Participant, robot2Participant, isByeMatch);
+  const stats2 = await updateRobotStats(robot2, battle, robot2Participant, robot1Participant, isByeMatch);
+  
+  const totalPrestige = stats1.prestigeAwarded + stats2.prestigeAwarded;
+  const totalFame = stats1.fameAwarded + stats2.fameAwarded;
+  
+  // Calculate and award streaming revenue (parallel — independent per robot)
+  let streamingRevenue1 = null;
+  let streamingRevenue2 = null;
+  
+  if (!isByeMatch) {
+    [streamingRevenue1, streamingRevenue2] = await Promise.all([
+      awardStreamingRevenueForParticipant(robot1.id, robot1.userId, battle.id, false),
+      awardStreamingRevenueForParticipant(robot2.id, robot2.userId, battle.id, false),
+    ]);
+    
+    if (streamingRevenue1) {
+      logger.info(`[Streaming] ${robot1.name} earned ₡${streamingRevenue1.totalRevenue.toLocaleString()} from Battle #${battle.id}`);
+    }
+    if (streamingRevenue2) {
+      logger.info(`[Streaming] ${robot2.name} earned ₡${streamingRevenue2.totalRevenue.toLocaleString()} from Battle #${battle.id}`);
+    }
+  }
+  
+  // Determine results for each robot (participants already fetched above)
   const robot1IsWinner = result.winnerId === robot1.id;
   const robot2IsWinner = result.winnerId === robot2.id;
   
-  // Log battle_complete events to audit log - ONE EVENT PER ROBOT (via shared helper)
-  await logBattleAuditEvent(
-    {
-      robotId: robot1.id,
-      userId: robot1.userId,
-      isWinner: robot1IsWinner,
-      isDraw: result.isDraw,
-      damageDealt: robot1Participant.damageDealt,
-      finalHP: robot1Participant.finalHP,
-      yielded: robot1Participant.yielded,
-      destroyed: robot1Participant.destroyed,
-      credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-      prestige: stats1.prestigeAwarded,
-      fame: stats1.fameAwarded,
-      eloBefore: robot1Participant.eloBefore,
-      eloAfter: robot1Participant.eloAfter,
-    },
-    { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-    robot2.id,
-    streamingRevenue1?.totalRevenue || 0,
-    result.isByeMatch,
-  );
-  
-  await logBattleAuditEvent(
-    {
-      robotId: robot2.id,
-      userId: robot2.userId,
-      isWinner: robot2IsWinner,
-      isDraw: result.isDraw,
-      damageDealt: robot2Participant.damageDealt,
-      finalHP: robot2Participant.finalHP,
-      yielded: robot2Participant.yielded,
-      destroyed: robot2Participant.destroyed,
-      credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-      prestige: stats2.prestigeAwarded,
-      fame: stats2.fameAwarded,
-      eloBefore: robot2Participant.eloBefore,
-      eloAfter: robot2Participant.eloAfter,
-    },
-    { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-    robot1.id,
-    streamingRevenue2?.totalRevenue || 0,
-    result.isByeMatch,
-  );
+  // Log battle_complete events to audit log - ONE EVENT PER ROBOT (parallel — independent writes)
+  await Promise.all([
+    logBattleAuditEvent(
+      {
+        robotId: robot1.id,
+        userId: robot1.userId,
+        isWinner: robot1IsWinner,
+        isDraw: result.isDraw,
+        damageDealt: robot1Participant.damageDealt,
+        finalHP: robot1Participant.finalHP,
+        yielded: robot1Participant.yielded,
+        destroyed: robot1Participant.destroyed,
+        credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+        prestige: stats1.prestigeAwarded,
+        fame: stats1.fameAwarded,
+        eloBefore: robot1Participant.eloBefore,
+        eloAfter: robot1Participant.eloAfter,
+      },
+      { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+      robot2.id,
+      streamingRevenue1?.totalRevenue || 0,
+      result.isByeMatch,
+    ),
+    logBattleAuditEvent(
+      {
+        robotId: robot2.id,
+        userId: robot2.userId,
+        isWinner: robot2IsWinner,
+        isDraw: result.isDraw,
+        damageDealt: robot2Participant.damageDealt,
+        finalHP: robot2Participant.finalHP,
+        yielded: robot2Participant.yielded,
+        destroyed: robot2Participant.destroyed,
+        credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+        prestige: stats2.prestigeAwarded,
+        fame: stats2.fameAwarded,
+        eloBefore: robot2Participant.eloBefore,
+        eloAfter: robot2Participant.eloAfter,
+      },
+      { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+      robot1.id,
+      streamingRevenue2?.totalRevenue || 0,
+      result.isByeMatch,
+    ),
+  ]);
   
   // Prestige/fame awards are already stored in BattleParticipant records
   // No need to update Battle table
@@ -777,15 +732,13 @@ export async function processBattle(scheduledMatch: ScheduledLeagueMatch): Promi
   
   // Consolidated battle completion log
   const winnerName = result.winnerId ? (result.winnerId === robot1.id ? robot1.name : robot2.name) : 'Draw';
-  const robot1User = await prisma.user.findUnique({ where: { id: robot1.userId }, select: { id: true } });
-  const robot2User = await prisma.user.findUnique({ where: { id: robot2.userId }, select: { id: true } });
   
   // Check for kills from BattleParticipant data (reuse variables from earlier)
   const robot1Killed = robot2Participant?.destroyed || false;
   const robot2Killed = robot1Participant?.destroyed || false;
   const killInfo = robot1Killed ? ` | Kill: ${robot1.name}` : (robot2Killed ? ` | Kill: ${robot2.name}` : '');
   
-  logger.info(`[Battle] League: ${battle.leagueType} | ${robot1.name} (User ${robot1User?.id}) vs ${robot2.name} (User ${robot2User?.id}) | Winner: ${winnerName} | Rewards: ₡${battle.winnerReward?.toLocaleString() || 0} / ₡${battle.loserReward?.toLocaleString() || 0} | Prestige: +${totalPrestige} | Fame: +${totalFame}${killInfo}`);
+  logger.info(`[Battle] League: ${battle.leagueType} | ${robot1.name} (User ${robot1.userId}) vs ${robot2.name} (User ${robot2.userId}) | Winner: ${winnerName} | Rewards: ₡${battle.winnerReward?.toLocaleString() || 0} / ₡${battle.loserReward?.toLocaleString() || 0} | Prestige: +${totalPrestige} | Fame: +${totalFame}${killInfo}`);
   
   return {
     ...result,
@@ -841,36 +794,17 @@ export async function executeScheduledBattles(_scheduledFor?: Date): Promise<Bat
         summary.byeBattles++;
       }
       
-      // Track streaming revenue from BattleParticipant records (more reliable than audit log)
-      if (!result.isByeMatch) {
-        const participants = await prisma.battleParticipant.findMany({
-          where: { battleId: result.battleId },
-          select: { streamingRevenue: true },
-        });
-        const totalStreaming = participants.reduce((sum, p) => sum + (p.streamingRevenue || 0), 0);
-        summary.totalStreamingRevenue = (summary.totalStreamingRevenue || 0) + totalStreaming;
-      }
-      
-      // Track reputation awards
+      // Track reputation awards (league type already known from the scheduled match)
       if (summary.reputationSummary) {
         summary.reputationSummary.totalPrestigeAwarded += result.prestigeAwarded;
         summary.reputationSummary.totalFameAwarded += result.fameAwarded;
         
-        // Track by league if there was a winner
         if (result.prestigeAwarded > 0 || result.fameAwarded > 0) {
-          // Get winner's league
-          const robot = await prisma.robot.findUnique({ 
-            where: { id: result.winnerId || 0 },
-            select: { currentLeague: true }
-          });
-          
-          if (robot) {
-            const league = robot.currentLeague;
-            summary.reputationSummary.prestigeByLeague[league] = 
-              (summary.reputationSummary.prestigeByLeague[league] || 0) + result.prestigeAwarded;
-            summary.reputationSummary.fameByLeague[league] = 
-              (summary.reputationSummary.fameByLeague[league] || 0) + result.fameAwarded;
-          }
+          const league = match.leagueType;
+          summary.reputationSummary.prestigeByLeague[league] = 
+            (summary.reputationSummary.prestigeByLeague[league] || 0) + result.prestigeAwarded;
+          summary.reputationSummary.fameByLeague[league] = 
+            (summary.reputationSummary.fameByLeague[league] || 0) + result.fameAwarded;
         }
       }
     } catch (error) {

--- a/app/backend/src/services/moderation/__tests__/imageUploadHandlers.property.test.ts
+++ b/app/backend/src/services/moderation/__tests__/imageUploadHandlers.property.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../common/eventLogger', () => ({
 jest.mock('../../security/securityMonitor', () => ({
   securityMonitor: {
     recordEvent: jest.fn(),
+    logSecurityEvent: jest.fn(),
     trackRateLimitViolation: jest.fn(),
   },
 }));
@@ -71,7 +72,7 @@ import { fileStorageService } from '../fileStorageService';
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockEventLogger = eventLogger as jest.Mocked<typeof eventLogger>;
-const mockSecurityMonitor = securityMonitor as unknown as { recordEvent: jest.Mock };
+const mockSecurityMonitor = securityMonitor as unknown as { recordEvent: jest.Mock; logSecurityEvent: jest.Mock };
 const mockFileValidation = fileValidationService as jest.Mocked<typeof fileValidationService>;
 const mockModeration = contentModerationService as jest.Mocked<typeof contentModerationService>;
 const mockImageProcessing = imageProcessingService as jest.Mocked<typeof imageProcessingService>;
@@ -342,12 +343,10 @@ describe('Property 10: Dual audit logging for NSFW rejections', () => {
           expect(options).toEqual(expect.objectContaining({ userId }));
 
           // SecurityMonitor event
-          expect(mockSecurityMonitor.recordEvent).toHaveBeenCalledTimes(1);
-          const smEvent = mockSecurityMonitor.recordEvent.mock.calls[0][0];
-          expect(smEvent.eventType).toBe('image_moderation_rejection');
-          expect(smEvent.severity).toBe('warning');
-          expect(smEvent.userId).toBe(userId);
-          expect(smEvent.details.robotId).toBe(robotId);
+          expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledTimes(1);
+          expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledWith(
+            'warning', 'image_moderation_rejection', userId, expect.objectContaining({ robotId }),
+          );
         },
       ),
       { numRuns: NUM_RUNS },

--- a/app/backend/src/services/moderation/__tests__/imageUploadHandlers.test.ts
+++ b/app/backend/src/services/moderation/__tests__/imageUploadHandlers.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../common/eventLogger', () => ({
 jest.mock('../../security/securityMonitor', () => ({
   securityMonitor: {
     recordEvent: jest.fn(),
+    logSecurityEvent: jest.fn(),
     trackRateLimitViolation: jest.fn(),
   },
 }));
@@ -70,7 +71,7 @@ import { fileStorageService } from '../fileStorageService';
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockEventLogger = eventLogger as jest.Mocked<typeof eventLogger>;
-const mockSecurityMonitor = securityMonitor as unknown as { recordEvent: jest.Mock; trackRateLimitViolation: jest.Mock };
+const mockSecurityMonitor = securityMonitor as unknown as { recordEvent: jest.Mock; logSecurityEvent: jest.Mock; trackRateLimitViolation: jest.Mock };
 const mockFileValidation = fileValidationService as jest.Mocked<typeof fileValidationService>;
 const mockModeration = contentModerationService as jest.Mocked<typeof contentModerationService>;
 const mockImageProcessing = imageProcessingService as jest.Mocked<typeof imageProcessingService>;
@@ -196,9 +197,9 @@ describe('handleImagePreview', () => {
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'IMAGE_MODERATION_FAILED' }));
     // Dual audit log
     expect(mockEventLogger.logEvent).toHaveBeenCalledTimes(1);
-    expect(mockSecurityMonitor.recordEvent).toHaveBeenCalledTimes(1);
-    expect(mockSecurityMonitor.recordEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'image_moderation_rejection', severity: 'warning' }),
+    expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledTimes(1);
+    expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledWith(
+      'warning', 'image_moderation_rejection', 1, expect.objectContaining({ robotId: 10 }),
     );
     // No scores in response
     const body = res.json.mock.calls[0][0];
@@ -219,8 +220,8 @@ describe('handleImagePreview', () => {
     expect(mockEventLogger.logEvent).toHaveBeenCalledWith(
       0, 'image_robot_likeness_warning', expect.anything(), expect.anything(),
     );
-    expect(mockSecurityMonitor.recordEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'image_robot_likeness_warning' }),
+    expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledWith(
+      'info', 'image_robot_likeness_warning', 1, expect.objectContaining({ robotId: 10 }),
     );
   });
 
@@ -239,8 +240,8 @@ describe('handleImagePreview', () => {
     expect(mockEventLogger.logEvent).toHaveBeenCalledWith(
       0, 'image_robot_likeness_override', expect.anything(), expect.anything(),
     );
-    expect(mockSecurityMonitor.recordEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'image_robot_likeness_override' }),
+    expect(mockSecurityMonitor.logSecurityEvent).toHaveBeenCalledWith(
+      'info', 'image_robot_likeness_override', 1, expect.objectContaining({ robotId: 10 }),
     );
   });
 

--- a/app/backend/src/services/moderation/fileStorageService.ts
+++ b/app/backend/src/services/moderation/fileStorageService.ts
@@ -46,11 +46,19 @@ class FileStorageService {
   /**
    * Resolve a relative URL path (e.g. /uploads/user-robots/42/abc.webp)
    * to an absolute filesystem path.
+   * Throws if the resolved path escapes the upload directory (path traversal protection).
    */
   getAbsolutePath(relativePath: string): string {
     // Strip leading /uploads/user-robots/ to get the sub-path, then join with UPLOAD_BASE_DIR
     const subPath = relativePath.replace(/^\/uploads\/user-robots\//, '');
-    return path.join(UPLOAD_BASE_DIR, subPath);
+    const resolved = path.resolve(UPLOAD_BASE_DIR, subPath);
+
+    // Ensure resolved path stays within the upload directory
+    if (!resolved.startsWith(UPLOAD_BASE_DIR + path.sep) && resolved !== UPLOAD_BASE_DIR) {
+      throw new Error(`Path traversal attempt detected: ${relativePath}`);
+    }
+
+    return resolved;
   }
 
   /**

--- a/app/backend/src/services/moderation/imageUploadHandlers.ts
+++ b/app/backend/src/services/moderation/imageUploadHandlers.ts
@@ -19,7 +19,7 @@ import { contentModerationService } from './contentModerationService';
 import { imageProcessingService } from './imageProcessingService';
 import { pendingUploadCache } from './pendingUploadCache';
 import { fileStorageService } from './fileStorageService';
-import { SecuritySeverity, SecurityEvent } from '../security/securityLogger';
+import { SecuritySeverity } from '../security/securityLogger';
 import logger from '../../config/logger';
 
 /**
@@ -79,13 +79,10 @@ export async function handleImagePreview(req: AuthRequest, res: Response): Promi
       timestamp: new Date().toISOString(),
     }, { userId });
 
-    (securityMonitor as unknown as { recordEvent(event: SecurityEvent): void }).recordEvent({
-      severity: SecuritySeverity.WARNING,
-      eventType: 'image_moderation_rejection',
-      userId,
-      details: { robotId, reason: moderation.reason },
-      timestamp: new Date().toISOString(),
-    } as SecurityEvent);
+    securityMonitor.logSecurityEvent(SecuritySeverity.WARNING, 'image_moderation_rejection', userId, {
+      robotId,
+      reason: moderation.reason,
+    });
 
     res.status(422).json({
       error: 'Image did not pass content moderation',
@@ -102,13 +99,10 @@ export async function handleImagePreview(req: AuthRequest, res: Response): Promi
       timestamp: new Date().toISOString(),
     }, { userId });
 
-    (securityMonitor as unknown as { recordEvent(event: SecurityEvent): void }).recordEvent({
-      severity: SecuritySeverity.INFO,
-      eventType: 'image_robot_likeness_warning',
-      userId,
-      details: { robotId, robotLikenessScore: moderation.robotLikenessScore },
-      timestamp: new Date().toISOString(),
-    } as SecurityEvent);
+    securityMonitor.logSecurityEvent(SecuritySeverity.INFO, 'image_robot_likeness_warning', userId, {
+      robotId,
+      robotLikenessScore: moderation.robotLikenessScore,
+    });
 
     res.status(422).json({
       error: "This doesn't look like a robot",
@@ -125,13 +119,10 @@ export async function handleImagePreview(req: AuthRequest, res: Response): Promi
       timestamp: new Date().toISOString(),
     }, { userId });
 
-    (securityMonitor as unknown as { recordEvent(event: SecurityEvent): void }).recordEvent({
-      severity: SecuritySeverity.INFO,
-      eventType: 'image_robot_likeness_override',
-      userId,
-      details: { robotId, robotLikenessScore: moderation.robotLikenessScore },
-      timestamp: new Date().toISOString(),
-    } as SecurityEvent);
+    securityMonitor.logSecurityEvent(SecuritySeverity.INFO, 'image_robot_likeness_override', userId, {
+      robotId,
+      robotLikenessScore: moderation.robotLikenessScore,
+    });
   }
 
   // Step 5: Process image to 512×512 WebP

--- a/app/backend/src/services/robot/robotQueryService.ts
+++ b/app/backend/src/services/robot/robotQueryService.ts
@@ -46,13 +46,19 @@ type BattleWithParticipants = Prisma.BattleGetPayload<{
 
 // ── GET /all/robots ──────────────────────────────────────────────────
 
-export async function findAllRobots() {
+export async function findAllRobots(page = 1, perPage = 100) {
+  // Clamp inputs to prevent invalid skip/take values
+  const safePage = Math.max(1, Math.floor(page));
+  const safePerPage = Math.min(200, Math.max(1, Math.floor(perPage)));
+
   return prisma.robot.findMany({
     include: {
       user: { select: { username: true } },
       ...WEAPON_INCLUDE,
     },
     orderBy: { elo: 'desc' },
+    skip: (safePage - 1) * safePerPage,
+    take: safePerPage,
   });
 }
 

--- a/app/backend/src/services/security/securityMonitor.ts
+++ b/app/backend/src/services/security/securityMonitor.ts
@@ -40,11 +40,17 @@ class SecurityMonitor {
 
   /** Cache of userId → stableName for enriching events without DB calls on every event */
   private stableNameCache = new Map<number, string>();
+  private static readonly MAX_STABLE_NAME_CACHE_SIZE = 1000;
 
   // ── helpers ──────────────────────────────────────────────────────────
 
   /** Set the stable name for a user (called by middleware/routes that have user context). */
   setStableName(userId: number, stableName: string): void {
+    // Evict oldest entry if cache is full (LRU-style via Map insertion order)
+    if (this.stableNameCache.size >= SecurityMonitor.MAX_STABLE_NAME_CACHE_SIZE && !this.stableNameCache.has(userId)) {
+      const firstKey = this.stableNameCache.keys().next().value;
+      if (firstKey !== undefined) this.stableNameCache.delete(firstKey);
+    }
     this.stableNameCache.set(userId, stableName);
   }
 
@@ -85,6 +91,20 @@ class SecurityMonitor {
   }
 
   // ── public API ───────────────────────────────────────────────────────
+
+  /**
+   * Log a generic security event (e.g., moderation events, custom alerts).
+   * Provides a public interface to recordEvent without exposing internals.
+   */
+  logSecurityEvent(severity: SecuritySeverity, eventType: string, userId: number | undefined, details: Record<string, unknown>): void {
+    this.recordEvent({
+      severity,
+      eventType,
+      userId,
+      details,
+      timestamp: new Date().toISOString(),
+    });
+  }
 
   /**
    * Track a spending event for rapid-spending detection (Req 7.1).

--- a/app/backend/src/services/tag-team/tagTeamBattleOrchestrator.ts
+++ b/app/backend/src/services/tag-team/tagTeamBattleOrchestrator.ts
@@ -17,7 +17,6 @@ import {
   didRobotLosePreviousBattle,
 } from '../battle/battlePostCombat';
 import { TagTeamError, TagTeamErrorCode } from '../../errors/tagTeamErrors';
-import { CycleEventPayload } from '../../types/snapshotTypes';
 import { prepareRobotForCombat } from '../../utils/robotCalculations';
 import { getTuningBonusesBatch } from '../tuning-pool';
 
@@ -1391,7 +1390,6 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
   draws: number;
   losses: number;
   skippedDueToUnreadyRobots: number;
-  totalStreamingRevenue?: number;
 }> {
   // Query scheduled tag team matches
   // Execute all matches with status 'scheduled' — the cron job controls timing,
@@ -1405,12 +1403,14 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
         include: {
           activeRobot: true,
           reserveRobot: true,
+          stable: true,
         },
       },
       team2: {
         include: {
           activeRobot: true,
           reserveRobot: true,
+          stable: true,
         },
       },
     },
@@ -1426,7 +1426,6 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
   let draws = 0;
   let losses = 0;
   let skippedDueToUnreadyRobots = 0;
-  let totalStreamingRevenue = 0;
 
   for (const match of scheduledMatches) {
     try {
@@ -1468,22 +1467,7 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
         losses++;
       }
 
-      // Track streaming revenue from audit log (per-robot battle_complete events)
-      if (!isByeMatch) {
-        const battleCompleteEvents = await prisma.auditLog.findMany({
-          where: {
-            eventType: 'battle_complete',
-            battleId: result.battleId,
-          },
-        });
-        
-        for (const evt of battleCompleteEvents) {
-          const payload = evt.payload as unknown as CycleEventPayload;
-          totalStreamingRevenue += payload?.streamingRevenue || 0;
-        }
-      }
-
-      // Update robot stats and apply rewards
+      // Update robot stats and apply rewards (streaming revenue tracked inside)
       await updateTagTeamBattleResults(match, result);
 
     } catch (error) {
@@ -1502,9 +1486,6 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
     `${wins} wins, ${draws} draws, ${losses} losses, ` +
     `${skippedDueToUnreadyRobots} skipped due to unready robots`
   );
-  if (totalStreamingRevenue > 0) {
-    logger.info(`[TagTeamBattles] Streaming Revenue: ₡${totalStreamingRevenue.toLocaleString()} total earned`);
-  }
 
   return {
     totalBattles,
@@ -1512,7 +1493,6 @@ export async function executeScheduledTagTeamBattles(_scheduledFor?: Date): Prom
     draws,
     losses,
     skippedDueToUnreadyRobots,
-    totalStreamingRevenue,
   };
 }
 
@@ -1545,32 +1525,20 @@ async function checkTeamReadinessForBattle(team: {
  * Requirements 12.4, 12.5: Full rewards for bye-team wins, normal penalties for losses
  */
 async function updateTagTeamBattleResults(
-  match: ScheduledTagTeamMatch,
+  match: ScheduledTagTeamMatch & {
+    team1: (TagTeam & { activeRobot: Robot; reserveRobot: Robot; stable: { id: number; stableName: string | null } | null }) | null;
+    team2: (TagTeam & { activeRobot: Robot; reserveRobot: Robot; stable: { id: number; stableName: string | null } | null }) | null;
+  },
   result: TagTeamBattleResult
 ): Promise<void> {
-  // Check if this is a bye-team match
-  const isByeMatch = match.team1Id === -1 || match.team2Id === -1;
-  const team1IsBye = match.team1Id === -1;
-  const team2IsBye = match.team2Id === -1;
+  // Check if this is a bye-team match (bye matches have team2Id = null in the DB)
+  const isByeMatch = match.team2Id === null;
+  const team1IsBye = false; // Team 1 is never the bye team (matchmaking always puts real team as team1)
+  const team2IsBye = match.team2Id === null;
 
-  // Load teams with full robot data (skip bye-teams)
-  const team1 = team1IsBye ? null : await prisma.tagTeam.findUnique({
-    where: { id: match.team1Id },
-    include: {
-      activeRobot: true,
-      reserveRobot: true,
-      stable: true,
-    },
-  });
-
-  const team2 = team2IsBye ? null : (match.team2Id ? await prisma.tagTeam.findUnique({
-    where: { id: match.team2Id },
-    include: {
-      activeRobot: true,
-      reserveRobot: true,
-      stable: true,
-    },
-  }) : null);
+  // Use pre-loaded teams from the scheduled match query (no re-fetch needed)
+  const team1 = team1IsBye ? null : match.team1;
+  const team2 = team2IsBye ? null : match.team2;
 
   // For bye-team matches, only update the real team
   if (isByeMatch) {
@@ -1603,31 +1571,9 @@ async function updateTagTeamBattleResults(
     const realTeamRewards = calculateTagTeamRewards(match.tagTeamLeague, realTeamWon, isDraw);
 
     // Calculate repair costs
-    const repairBay = await prisma.facility.findUnique({
-      where: {
-        userId_facilityType: {
-          userId: realTeam.stableId,
-          facilityType: 'repair_bay',
-        },
-      },
-    });
-    const medicalBay = await prisma.facility.findUnique({
-      where: {
-        userId_facilityType: {
-          userId: realTeam.stableId,
-          facilityType: 'medical_bay',
-        },
-      },
-    });
-    const _activeRobotCount = await prisma.robot.count({
-      where: {
-        userId: realTeam.stableId,
-        NOT: { name: 'Bye Robot' }
-      }
-    });
-
-    const _repairBayLevel = repairBay ? repairBay.level : 0;
-    const _medicalBayLevel = medicalBay ? medicalBay.level : 0;
+    // NOTE: Repair costs are NOT calculated here anymore
+    // They are calculated by RepairService when repairs are actually triggered
+    // This ensures accurate costs based on current damage and facility levels
 
     const activeFinalHP = team1IsBye ? result.team2ActiveFinalHP : result.team1ActiveFinalHP;
     const reserveFinalHP = team1IsBye ? result.team2ReserveFinalHP : result.team1ReserveFinalHP;
@@ -1812,58 +1758,6 @@ async function updateTagTeamBattleResults(
   const team2Rewards = calculateTagTeamRewards(match.tagTeamLeague, team2Won, isDraw);
 
   // Calculate repair costs (Requirements 4.4, 4.5, 4.6, 4.7)
-  // Get Repair Bay discount for each stable
-  const team1RepairBay = await prisma.facility.findUnique({
-    where: {
-      userId_facilityType: {
-        userId: team1.stableId,
-        facilityType: 'repair_bay',
-      },
-    },
-  });
-  const team2RepairBay = await prisma.facility.findUnique({
-    where: {
-      userId_facilityType: {
-        userId: team2.stableId,
-        facilityType: 'repair_bay',
-      },
-    },
-  });
-  const team1MedicalBay = await prisma.facility.findUnique({
-    where: {
-      userId_facilityType: {
-        userId: team1.stableId,
-        facilityType: 'medical_bay',
-      },
-    },
-  });
-  const team2MedicalBay = await prisma.facility.findUnique({
-    where: {
-      userId_facilityType: {
-        userId: team2.stableId,
-        facilityType: 'medical_bay',
-      },
-    },
-  });
-
-  const _team1ActiveRobotCount = await prisma.robot.count({
-    where: {
-      userId: team1.stableId,
-      NOT: { name: 'Bye Robot' }
-    }
-  });
-  const _team2ActiveRobotCount = await prisma.robot.count({
-    where: {
-      userId: team2.stableId,
-      NOT: { name: 'Bye Robot' }
-    }
-  });
-
-  const _team1RepairBayLevel = team1RepairBay ? team1RepairBay.level : 0;
-  const _team2RepairBayLevel = team2RepairBay ? team2RepairBay.level : 0;
-  const _team1MedicalBayLevel = team1MedicalBay ? team1MedicalBay.level : 0;
-  const _team2MedicalBayLevel = team2MedicalBay ? team2MedicalBay.level : 0;
-
   // NOTE: Repair costs are NOT calculated here anymore
   // They are calculated by RepairService when repairs are actually triggered
   // This ensures accurate costs based on current damage and facility levels

--- a/app/backend/src/services/tag-team/tagTeamLeagueInstanceService.ts
+++ b/app/backend/src/services/tag-team/tagTeamLeagueInstanceService.ts
@@ -377,7 +377,8 @@ type TagTeamWithRobotsAndStable = Prisma.TagTeamGetPayload<{
 /**
  * Get standings for an entire tag team league tier (all instances combined)
  * Requirement 9.3: Sort by league points (descending), then ELO (descending)
- * Includes team rank calculation
+ * Includes team rank calculation.
+ * Capped at 500 teams max to prevent unbounded memory usage.
  */
 export async function getStandingsForTier(tier: TagTeamLeagueTier): Promise<(TagTeamWithRobotsAndStable & { combinedELO: number; rank: number })[]> {
   const teams = await prisma.tagTeam.findMany({
@@ -403,6 +404,11 @@ export async function getStandingsForTier(tier: TagTeamLeagueTier): Promise<(Tag
         },
       },
     },
+    orderBy: { tagTeamLeaguePoints: 'desc' },
+    // Cap at 500 to prevent unbounded memory usage. Current game has ~50 teams
+    // per tier max. If tiers grow beyond 500, this should be replaced with
+    // proper DB-level pagination (skip/take passed from the route handler).
+    take: 500,
   });
 
   // Calculate combined ELO for each team and sort

--- a/app/backend/src/utils/economyCalculations.ts
+++ b/app/backend/src/utils/economyCalculations.ts
@@ -574,16 +574,25 @@ export async function processAllDailyFinances(): Promise<{
   let totalCostsDeducted = 0;
   let bankruptUsers = 0;
 
-  for (const user of users) {
-    try {
-      const summary = await processDailyFinances(user.id);
-      summaries.push(summary);
-      totalCostsDeducted += summary.totalCosts;
-      if (summary.isBankrupt) {
-        bankruptUsers++;
+  // Process users in parallel batches of 20 to avoid overwhelming the DB connection pool
+  const BATCH_SIZE = 20;
+  for (let i = 0; i < users.length; i += BATCH_SIZE) {
+    const batch = users.slice(i, i + BATCH_SIZE);
+    const batchResults = await Promise.allSettled(
+      batch.map(user => processDailyFinances(user.id))
+    );
+
+    for (let j = 0; j < batchResults.length; j++) {
+      const result = batchResults[j];
+      if (result.status === 'fulfilled') {
+        summaries.push(result.value);
+        totalCostsDeducted += result.value.totalCosts;
+        if (result.value.isBankrupt) {
+          bankruptUsers++;
+        }
+      } else {
+        logger.error(`[Daily Finances] Error processing user ${batch[j].id}:`, result.reason);
       }
-    } catch (error) {
-      logger.error(`[Daily Finances] Error processing user ${user.id}:`, error);
     }
   }
 

--- a/app/frontend/src/components/admin/CycleControlsTab.tsx
+++ b/app/frontend/src/components/admin/CycleControlsTab.tsx
@@ -232,6 +232,101 @@ export function CycleControlsTab({
     }
   };
 
+  const triggerTournamentCycle = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const response = await apiClient.post('/api/admin/cycles/bulk', {
+        cycles: 0,
+        includeTournaments: true,
+        includeKoth: false,
+        generateUsersPerCycle: false,
+      });
+      const results = response.data.results?.[0]?.tournaments;
+      const details = results
+        ? [
+            results.tournamentsExecuted ? `${results.tournamentsExecuted} tournament(s) executed` : null,
+            results.roundsExecuted ? `${results.roundsExecuted} round(s)` : null,
+            results.matchesExecuted ? `${results.matchesExecuted} match(es)` : null,
+            results.tournamentsCompleted ? `${results.tournamentsCompleted} completed` : null,
+            results.tournamentsCreated ? `${results.tournamentsCreated} created` : null,
+          ].filter(Boolean).join(', ')
+        : 'Tournament cycle triggered';
+      addSessionLog('success', `Tournament cycle: ${details || 'completed'}`);
+      showMessage('success', details || 'Tournament cycle completed');
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Tournament cycle trigger failed';
+      addSessionLog('error', `Tournament cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const triggerLeagueCycle = async (): Promise<void> => {
+    setLoading(true);
+    addSessionLog('info', 'Starting league cycle: Repair → Battles → Rebalance → Matchmaking');
+    try {
+      // Step 1: Repair
+      const repairRes = await apiClient.post('/api/admin/repair/all', { deductCosts: true });
+      addSessionLog('info', `Step 1: Repaired ${repairRes.data.robotsRepaired} robots`);
+
+      // Step 2: Execute battles
+      const battleRes = await apiClient.post('/api/admin/battles/run', {});
+      const bs = battleRes.data.summary;
+      addSessionLog(bs.failedBattles > 0 ? 'warning' : 'success',
+        `Step 2: ${bs.successfulBattles}/${bs.totalBattles} battles executed${bs.failedBattles > 0 ? ` (${bs.failedBattles} failed)` : ''}`);
+
+      // Step 3: Rebalance
+      const rebalRes = await apiClient.post('/api/admin/leagues/rebalance', {});
+      const rs = rebalRes.data.summary;
+      addSessionLog('success', `Step 3: Rebalanced — ${rs.totalPromoted} promoted, ${rs.totalDemoted} demoted`);
+
+      // Step 4: Matchmaking
+      const matchRes = await apiClient.post('/api/admin/matchmaking/run', {});
+      addSessionLog('success', `Step 4: ${matchRes.data.matchesCreated} matches scheduled`);
+
+      showMessage('success', `League cycle complete: ${bs.successfulBattles} battles, ${rs.totalPromoted} promoted, ${matchRes.data.matchesCreated} matches scheduled`);
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'League cycle failed';
+      addSessionLog('error', `League cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const triggerTagTeamCycle = async (): Promise<void> => {
+    setLoading(true);
+    addSessionLog('info', 'Starting tag team cycle: Repair → Battles → Rebalance → Matchmaking');
+    try {
+      // Step 1: Repair
+      const repairRes = await apiClient.post('/api/admin/repair/all', { deductCosts: true });
+      addSessionLog('info', `Step 1: Repaired ${repairRes.data.robotsRepaired} robots`);
+
+      // Step 2: Execute tag team battles
+      const battleRes = await apiClient.post('/api/admin/tag-teams/battles', {});
+      const bs = battleRes.data.summary;
+      addSessionLog('success', `Step 2: ${bs.totalBattles} tag team battles executed`);
+
+      // Step 3: Rebalance tag team leagues
+      const rebalRes = await apiClient.post('/api/admin/tag-teams/rebalance', {});
+      const rs = rebalRes.data.summary;
+      addSessionLog('success', `Step 3: Rebalanced — ${rs.totalPromoted} promoted, ${rs.totalDemoted} demoted`);
+
+      // Step 4: Tag team matchmaking
+      const matchRes = await apiClient.post('/api/admin/tag-teams/matchmaking', {});
+      addSessionLog('success', `Step 4: ${matchRes.data.matchesCreated} tag team matches scheduled`);
+
+      showMessage('success', `Tag team cycle complete: ${bs.totalBattles} battles, ${rs.totalPromoted} promoted, ${matchRes.data.matchesCreated} matches scheduled`);
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Tag team cycle failed';
+      addSessionLog('error', `Tag team cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   /* ---------- Bulk cycle runner ---------- */
 
   const runBulkCycles = async (): Promise<void> => {
@@ -350,53 +445,89 @@ export function CycleControlsTab({
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Daily Cycle Controls */}
+        {/* Production Cycle Triggers */}
         <div className="bg-surface rounded-lg p-6">
-          <h2 className="text-2xl font-bold mb-4">Daily Cycle Controls</h2>
+          <h2 className="text-2xl font-bold mb-2">Production Jobs (Manual Trigger)</h2>
+          <p className="text-secondary text-sm mb-4">Each button runs the same pipeline as the corresponding cron job.</p>
           <div className="grid grid-cols-1 gap-4">
             <button
-              onClick={repairAllRobots}
+              onClick={triggerLeagueCycle}
               disabled={loading}
-              className="bg-green-600 hover:bg-green-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
+              className="bg-primary hover:bg-blue-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors text-left"
             >
-              🔧 Auto-Repair All Robots
+              ⚔️ Run League Cycle
+              <span className="block text-xs font-normal opacity-75 mt-0.5">Repair → Execute battles → Rebalance → Matchmaking</span>
             </button>
             <button
-              onClick={runMatchmaking}
+              onClick={triggerTournamentCycle}
               disabled={loading}
-              className="bg-primary hover:bg-blue-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
+              className="bg-yellow-600 hover:bg-yellow-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors text-left"
             >
-              🎯 Run Matchmaking
+              🏆 Run Tournament Cycle
+              <span className="block text-xs font-normal opacity-75 mt-0.5">Repair → Execute rounds → Advance winners → Auto-create</span>
             </button>
             <button
-              onClick={executeBattles}
+              onClick={triggerTagTeamCycle}
               disabled={loading}
-              className="bg-red-600 hover:bg-red-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
+              className="bg-cyan-600 hover:bg-cyan-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors text-left"
             >
-              ⚔️ Execute Battles
-            </button>
-            <button
-              onClick={processDailyFinances}
-              disabled={loading}
-              className="bg-yellow-600 hover:bg-yellow-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
-            >
-              💰 Process Daily Finances
-            </button>
-            <button
-              onClick={rebalanceLeagues}
-              disabled={loading}
-              className="bg-purple-600 hover:bg-purple-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
-            >
-              📊 Rebalance Leagues
+              🤝 Run Tag Team Cycle
+              <span className="block text-xs font-normal opacity-75 mt-0.5">Repair → Execute battles → Rebalance → Matchmaking</span>
             </button>
             <button
               onClick={triggerKothCycle}
               disabled={loading}
-              className="bg-orange-600 hover:bg-orange-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors"
+              className="bg-orange-600 hover:bg-orange-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors text-left"
             >
-              👑 Trigger KotH Cycle
+              👑 Run KotH Cycle
+              <span className="block text-xs font-normal opacity-75 mt-0.5">Execute battles → Matchmaking for next round</span>
+            </button>
+            <button
+              onClick={processDailyFinances}
+              disabled={loading}
+              className="bg-green-600 hover:bg-green-700 disabled:bg-surface-elevated px-6 py-3 rounded font-semibold transition-colors text-left"
+            >
+              💰 Run Settlement
+              <span className="block text-xs font-normal opacity-75 mt-0.5">Passive income → Operating costs → Cycle counter → Snapshot</span>
             </button>
           </div>
+
+          {/* Individual Step Controls (collapsed) */}
+          <details className="mt-6">
+            <summary className="cursor-pointer text-secondary hover:text-white text-sm font-medium">
+              🔧 Individual Step Controls (debugging)
+            </summary>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+              <button
+                onClick={repairAllRobots}
+                disabled={loading}
+                className="bg-surface-elevated hover:bg-white/10 disabled:opacity-50 px-4 py-2 rounded text-sm transition-colors"
+              >
+                🔧 Repair All Robots
+              </button>
+              <button
+                onClick={runMatchmaking}
+                disabled={loading}
+                className="bg-surface-elevated hover:bg-white/10 disabled:opacity-50 px-4 py-2 rounded text-sm transition-colors"
+              >
+                🎯 Run Matchmaking (League)
+              </button>
+              <button
+                onClick={executeBattles}
+                disabled={loading}
+                className="bg-surface-elevated hover:bg-white/10 disabled:opacity-50 px-4 py-2 rounded text-sm transition-colors"
+              >
+                ⚔️ Execute League Battles
+              </button>
+              <button
+                onClick={rebalanceLeagues}
+                disabled={loading}
+                className="bg-surface-elevated hover:bg-white/10 disabled:opacity-50 px-4 py-2 rounded text-sm transition-colors"
+              >
+                📊 Rebalance Leagues
+              </button>
+            </div>
+          </details>
         </div>
 
         {/* Bulk Cycle Testing */}

--- a/app/frontend/src/components/admin/__tests__/CycleControlsTab.test.tsx
+++ b/app/frontend/src/components/admin/__tests__/CycleControlsTab.test.tsx
@@ -67,11 +67,11 @@ describe('CycleControlsTab', () => {
   it('should render all cycle control buttons', () => {
     render(<CycleControlsTab {...defaultProps} />);
 
-    expect(screen.getByRole('button', { name: /run matchmaking/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /execute battles/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /rebalance leagues/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /auto-repair all/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /process daily finances/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run league cycle/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run tournament cycle/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run tag team cycle/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run koth cycle/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run settlement/i })).toBeInTheDocument();
   });
 
   it('should render bulk cycle runner section', () => {

--- a/app/frontend/src/pages/admin/CycleControlsPage.tsx
+++ b/app/frontend/src/pages/admin/CycleControlsPage.tsx
@@ -190,6 +190,78 @@ function CycleControlsPage() {
     }
   };
 
+  const triggerLeagueCycle = async (): Promise<void> => {
+    setLoading(true);
+    addSessionLog('info', 'Starting league cycle: Repair → Battles → Rebalance → Matchmaking');
+    try {
+      const repairRes = await apiClient.post('/api/admin/repair/all', { deductCosts: true });
+      addSessionLog('info', `Step 1: Repaired ${repairRes.data.robotsRepaired} robots`);
+      const battleRes = await apiClient.post('/api/admin/battles/run', {});
+      const bs = battleRes.data.summary;
+      addSessionLog(bs.failedBattles > 0 ? 'warning' : 'success', `Step 2: ${bs.successfulBattles}/${bs.totalBattles} battles executed`);
+      const rebalRes = await apiClient.post('/api/admin/leagues/rebalance', {});
+      const rs = rebalRes.data.summary;
+      addSessionLog('success', `Step 3: ${rs.totalPromoted} promoted, ${rs.totalDemoted} demoted`);
+      const matchRes = await apiClient.post('/api/admin/matchmaking/run', {});
+      addSessionLog('success', `Step 4: ${matchRes.data.matchesCreated} matches scheduled`);
+      showMessage('success', `League cycle complete: ${bs.successfulBattles} battles, ${matchRes.data.matchesCreated} matches scheduled`);
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'League cycle failed';
+      addSessionLog('error', `League cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const triggerTournamentCycle = async (): Promise<void> => {
+    setLoading(true);
+    addSessionLog('info', 'Starting tournament cycle');
+    try {
+      const response = await apiClient.post('/api/admin/cycles/bulk', { cycles: 0, includeTournaments: true, includeKoth: false, generateUsersPerCycle: false });
+      const results = response.data.results?.[0]?.tournaments;
+      const details = results ? [
+        results.tournamentsExecuted ? `${results.tournamentsExecuted} tournament(s)` : null,
+        results.roundsExecuted ? `${results.roundsExecuted} round(s)` : null,
+        results.matchesExecuted ? `${results.matchesExecuted} match(es)` : null,
+        results.tournamentsCompleted ? `${results.tournamentsCompleted} completed` : null,
+        results.tournamentsCreated ? `${results.tournamentsCreated} created` : null,
+      ].filter(Boolean).join(', ') : 'completed';
+      addSessionLog('success', `Tournament cycle: ${details}`);
+      showMessage('success', `Tournament cycle: ${details}`);
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Tournament cycle failed';
+      addSessionLog('error', `Tournament cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const triggerTagTeamCycle = async (): Promise<void> => {
+    setLoading(true);
+    addSessionLog('info', 'Starting tag team cycle: Repair → Battles → Rebalance → Matchmaking');
+    try {
+      const repairRes = await apiClient.post('/api/admin/repair/all', { deductCosts: true });
+      addSessionLog('info', `Step 1: Repaired ${repairRes.data.robotsRepaired} robots`);
+      const battleRes = await apiClient.post('/api/admin/tag-teams/battles', {});
+      const bs = battleRes.data.summary;
+      addSessionLog('success', `Step 2: ${bs.totalBattles} tag team battles executed`);
+      const rebalRes = await apiClient.post('/api/admin/tag-teams/rebalance', {});
+      const rs = rebalRes.data.summary;
+      addSessionLog('success', `Step 3: ${rs.totalPromoted} promoted, ${rs.totalDemoted} demoted`);
+      const matchRes = await apiClient.post('/api/admin/tag-teams/matchmaking', {});
+      addSessionLog('success', `Step 4: ${matchRes.data.matchesCreated} tag team matches scheduled`);
+      showMessage('success', `Tag team cycle complete: ${bs.totalBattles} battles, ${matchRes.data.matchesCreated} matches scheduled`);
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Tag team cycle failed';
+      addSessionLog('error', `Tag team cycle failed: ${msg}`);
+      showMessage('error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   /* ---------- Bulk cycle runner ---------- */
 
   const runBulkCycles = useCallback(async (): Promise<void> => {
@@ -281,15 +353,28 @@ function CycleControlsPage() {
 
       {/* Production Jobs (Manual Trigger) */}
       <div className="bg-surface rounded-lg p-6">
-        <h2 className="text-xl font-semibold mb-4">Production Jobs (Manual Trigger)</h2>
+        <h2 className="text-xl font-semibold mb-2">Production Jobs (Manual Trigger)</h2>
+        <p className="text-sm text-secondary mb-4">Each button runs the same pipeline as the corresponding cron job.</p>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-          <TriggerButton label="🔧 Auto-Repair All Robots" color="bg-green-600 hover:bg-green-700" disabled={loading} onClick={() => requestConfirm('Auto-Repair All Robots', 'This will repair all damaged robots and deduct costs. Continue?', repairAllRobots)} />
-          <TriggerButton label="🎯 Run Matchmaking" color="bg-primary hover:bg-blue-700" disabled={loading} onClick={() => requestConfirm('Run Matchmaking', 'This will create new match pairings for all eligible robots. Continue?', runMatchmaking)} />
-          <TriggerButton label="⚔️ Execute Battles" color="bg-red-600 hover:bg-red-700" disabled={loading} onClick={() => requestConfirm('Execute Battles', 'This will execute all pending battles. This action cannot be undone. Continue?', executeBattles)} />
-          <TriggerButton label="💰 Process Daily Finances" color="bg-yellow-600 hover:bg-yellow-700" disabled={loading} onClick={() => requestConfirm('Process Daily Finances', 'This will deduct daily costs and process income for all users. Continue?', processDailyFinances)} />
-          <TriggerButton label="📊 Rebalance Leagues" color="bg-purple-600 hover:bg-purple-700" disabled={loading} onClick={() => requestConfirm('Rebalance Leagues', 'This will promote and demote robots based on their ELO. Continue?', rebalanceLeagues)} />
-          <TriggerButton label="👑 Trigger KotH Cycle" color="bg-orange-600 hover:bg-orange-700" disabled={loading} onClick={() => requestConfirm('Trigger KotH Cycle', 'This will trigger a King of the Hill cycle. Continue?', triggerKothCycle)} />
+          <TriggerButton label="⚔️ Run League Cycle" color="bg-primary hover:bg-blue-700" disabled={loading} onClick={() => requestConfirm('Run League Cycle', 'Repair → Execute battles → Rebalance → Matchmaking. Continue?', triggerLeagueCycle)} />
+          <TriggerButton label="🏆 Run Tournament Cycle" color="bg-yellow-600 hover:bg-yellow-700" disabled={loading} onClick={() => requestConfirm('Run Tournament Cycle', 'Repair → Execute rounds → Advance winners → Auto-create. Continue?', triggerTournamentCycle)} />
+          <TriggerButton label="🤝 Run Tag Team Cycle" color="bg-cyan-600 hover:bg-cyan-700" disabled={loading} onClick={() => requestConfirm('Run Tag Team Cycle', 'Repair → Execute battles → Rebalance → Matchmaking. Continue?', triggerTagTeamCycle)} />
+          <TriggerButton label="👑 Run KotH Cycle" color="bg-orange-600 hover:bg-orange-700" disabled={loading} onClick={() => requestConfirm('Run KotH Cycle', 'Execute KotH battles → Matchmaking for next round. Continue?', triggerKothCycle)} />
+          <TriggerButton label="💰 Run Settlement" color="bg-green-600 hover:bg-green-700" disabled={loading} onClick={() => requestConfirm('Run Settlement', 'Passive income → Operating costs → Cycle counter → Snapshot. Continue?', processDailyFinances)} />
         </div>
+
+        {/* Individual Step Controls (debugging) */}
+        <details className="mt-4">
+          <summary className="cursor-pointer text-secondary hover:text-white text-sm font-medium">
+            🔧 Individual Step Controls (debugging)
+          </summary>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 mt-3">
+            <TriggerButton label="🔧 Repair All Robots" color="bg-surface-elevated hover:bg-white/10" disabled={loading} onClick={() => requestConfirm('Repair All Robots', 'Repair all damaged robots and deduct costs?', repairAllRobots)} />
+            <TriggerButton label="🎯 Run Matchmaking (League)" color="bg-surface-elevated hover:bg-white/10" disabled={loading} onClick={() => requestConfirm('Run Matchmaking', 'Create new league match pairings?', runMatchmaking)} />
+            <TriggerButton label="⚔️ Execute League Battles" color="bg-surface-elevated hover:bg-white/10" disabled={loading} onClick={() => requestConfirm('Execute Battles', 'Execute all pending league battles?', executeBattles)} />
+            <TriggerButton label="📊 Rebalance Leagues" color="bg-surface-elevated hover:bg-white/10" disabled={loading} onClick={() => requestConfirm('Rebalance Leagues', 'Promote and demote robots?', rebalanceLeagues)} />
+          </div>
+        </details>
       </div>
 
       {/* Bulk Cycle Testing */}

--- a/app/frontend/src/pages/admin/__tests__/CycleControlsPage.test.tsx
+++ b/app/frontend/src/pages/admin/__tests__/CycleControlsPage.test.tsx
@@ -101,21 +101,20 @@ describe('CycleControlsPage', () => {
 
   it('should render production job trigger buttons', () => {
     render(<CycleControlsPage />);
-    expect(screen.getByText('🔧 Auto-Repair All Robots')).toBeInTheDocument();
-    expect(screen.getByText('🎯 Run Matchmaking')).toBeInTheDocument();
-    expect(screen.getByText('⚔️ Execute Battles')).toBeInTheDocument();
-    expect(screen.getByText('💰 Process Daily Finances')).toBeInTheDocument();
-    expect(screen.getByText('📊 Rebalance Leagues')).toBeInTheDocument();
-    expect(screen.getByText('👑 Trigger KotH Cycle')).toBeInTheDocument();
+    expect(screen.getByText('⚔️ Run League Cycle')).toBeInTheDocument();
+    expect(screen.getByText('🏆 Run Tournament Cycle')).toBeInTheDocument();
+    expect(screen.getByText('🤝 Run Tag Team Cycle')).toBeInTheDocument();
+    expect(screen.getByText('👑 Run KotH Cycle')).toBeInTheDocument();
+    expect(screen.getByText('💰 Run Settlement')).toBeInTheDocument();
   });
 
   it('should show confirmation dialog when a trigger button is clicked', async () => {
     const user = userEvent.setup();
     render(<CycleControlsPage />);
 
-    await user.click(screen.getByText('🎯 Run Matchmaking'));
+    await user.click(screen.getByText('⚔️ Run League Cycle'));
 
-    expect(screen.getByText('Run Matchmaking')).toBeInTheDocument();
+    expect(screen.getByText('Run League Cycle')).toBeInTheDocument();
     expect(screen.getByText('Confirm')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
@@ -124,11 +123,11 @@ describe('CycleControlsPage', () => {
     const user = userEvent.setup();
     render(<CycleControlsPage />);
 
-    await user.click(screen.getByText('🎯 Run Matchmaking'));
+    await user.click(screen.getByText('⚔️ Run League Cycle'));
     expect(screen.getByText('Confirm')).toBeInTheDocument();
 
     await user.click(screen.getByText('Cancel'));
-    expect(screen.queryByText('This will create new match pairings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Repair → Execute battles')).not.toBeInTheDocument();
   });
 
   it('should render bulk cycle testing section', () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Armoured Souls — Changelog
 
-**Last Updated**: April 9, 2026
+**Last Updated**: May 13, 2026
 
 Development history organized by phase and month. For the forward-looking roadmap, see [ROADMAP.md](ROADMAP.md).
 
@@ -22,7 +22,7 @@ Development history organized by phase and month. For the forward-looking roadma
 **Started**: January 24, 2026  
 **Status**: Feature-complete, deployed to production VPS
 
-Phase 1 delivered a fully functional game with 4 battle modes, 14 facilities, 47 weapons, a 5-step onboarding tutorial, automated daily cycles, and a production deployment on Scaleway. Development was tracked through 40 Kiro specs (22 in March, 18 in April) plus 23 earlier milestones.
+Phase 1 delivered a fully functional game with 4 battle modes, 15 facilities, 47 weapons, a 5-step onboarding tutorial, automated daily cycles, and a production deployment on Scaleway. Development was tracked through 52 Kiro specs (22 in March, 26 in April, 4 in May) plus 23 earlier milestones.
 
 ### Core Systems (Jan–Feb 2026)
 
@@ -67,7 +67,7 @@ Phase 1 delivered a fully functional game with 4 battle modes, 14 facilities, 47
 | Weapon Bonus Rebalance | Weapon attribute bonuses rebalanced across all 47 weapons |
 | Weapon & Roster Expansion | Storage facility limits, roster expansion enforcement |
 
-### April 2026 Specs (18 completed)
+### April 2026 Specs (26 completed)
 
 | # | Spec | Summary |
 |---|---|---|
@@ -88,7 +88,24 @@ Phase 1 delivered a fully functional game with 4 battle modes, 14 facilities, 47
 | 17 | Type Safety & Any Elimination | Removed `any` types, strict Prisma typing, typed JSON payloads |
 | 18 | Frontend Component Splitting | Large components decomposed into focused sub-components |
 | 19 | Frontend Testing Foundation | Vitest setup, component test patterns, coverage infrastructure |
+| 20 | Robot Image Upload | Custom robot images with nsfwjs content moderation, two-step upload flow (preview + confirm), sharp image processing, orphan cleanup, admin uploads visibility |
 | 21 | Service Layer Type Safety | Typed service interfaces, strict return types, Prisma payload typing |
+| 22 | Admin Password Reset | Secure admin password reset endpoint with PasswordResetService, session invalidation via token version, rate limiting, audit logging |
+| 23 | E2E Playwright Coverage | 11+ Playwright spec files covering registration, onboarding, robot creation, weapon shop, practice arena, financial flows, and CI blocking gate |
+| 24 | In-Game Changelog | "What's New" modal and dedicated page, auto-generated drafts from deploys, admin review/publish workflow, category badges, optional images |
+| 25 | Tuning Bay | Per-robot tactical attribute tuning with 23 sliders, facility-gated pool size (10–110 points), combat integration, onboarding auto-allocation |
+| 26 | Battle Report Overhaul | Statistics summary, Sankey damage flow diagram, responsive playback viewer, tabbed layout, design system alignment, CompactBattleCard economic enhancement |
+| 27 | Achievement System | 77-achievement progression layer with badges, progress tracking, rarity, pinned showcase, toast notifications, retroactive awards |
+| 28 | Admin Portal Redesign | Sidebar navigation, 18 lazy-loaded route pages, Zustand shared state, AdminRoute guard, 6 analytics dashboards, shared UI component library, server-side audit trail |
+
+### May 2026 Specs (4 completed)
+
+| # | Spec | Summary |
+|---|---|---|
+| 29 | Monitoring & Alerting | Discord webhook alerts for disk/startup/backup/deploy failures, enhanced health endpoint, daily health report, UptimeRobot external probes, Scaleway Cockpit integration |
+| 30 | Fix Investment Advisor | Unified ROI calculation from CycleSnapshot data, consolidated Investments & Advisor tabs, graceful degradation with incomplete audit data, economic-only facility filtering |
+| 31 | Weapon DPS Rebalance | baseDamage compression (3.0× → 2.0× DPS spread), differentiated top-tier weapon profiles (fast/standard/burst/heavy), Float schema migration, battle duration normalization (~34s → ~45s) |
+| 32 | League History Tracking | Persistent tier change tracking for robots and tag teams, admin analytics dashboard with yo-yo detection, player-facing timeline visualizations, achievement data support |
 
 ---
 


### PR DESCRIPTION
**Performance optimizations:**
- Battle orchestrator (league): remove 6 dead queries, eliminate redundant
  participant re-fetches, parallelize streaming revenue + audit log writes
- Battle orchestrator (tag team): remove 10 dead facility/robot-count queries,
  eliminate team re-loads, remove audit log re-query for streaming revenue
- Settlement cycle: batch-load all facilities/robots in 2 queries instead of
  2N, use logEventBatch for audit events (90% query reduction)
- Matchmaking: batch-fetch recent opponents in 1 query instead of N
- Achievement service: pre-fetch robot + user data once, pass cached data to
  all evaluators (eliminates 10-15 findUnique calls per evaluation)
- Repair service: batch-load facilities and robot counts for all affected users
- Event logger: remove unnecessary async lock mechanism (Node.js is single-threaded)
- Economy: parallel batch processing for daily finances (batches of 20)
- Admin stats: parallelize 8 sequential count queries
- Spending tracker: skip DB query entirely for post-onboarding users

**Security hardening:**
- Path traversal protection in fileStorageService.getAbsolutePath
- SecurityMonitor memory leak fix (LRU cache cap at 1000 entries)
- Rate limiter removed from GET /reset-eligibility (was blocking resets)
- Server-side token invalidation on logout via tokenVersion increment
- Public logSecurityEvent method replacing unsafe type casts
- findAllRobots and tag team standings capped/paginated

**CI/CD fix:**
- Move TypeScript build from VPS to CI runner (fixes 20min timeout on 2GB VPS)
- Transfer pre-built dist/ to VPS via rsync
- Add Node.js setup step to ACC deploy job

**Docs:**
- Add cycle architecture section to steering (cron jobs, not monolithic cycles)
- Add CI/CD tooling notes (gh CLI access, branch workflow)" 2>&1