### PR TITLE
fix: achievement date sort + KotH Last 10 Events (#306, #307)

### DIFF
--- a/app/backend/src/services/koth/kothStandingsService.ts
+++ b/app/backend/src/services/koth/kothStandingsService.ts
@@ -140,17 +140,18 @@ async function getKothStandingsLast10({ page, limit }: { page: number; limit: nu
 
   const total = allRobotStats.length;
   const paginatedStats = allRobotStats.slice((page - 1) * limit, page * limit);
+  const topRobotStats = allRobotStats.length > 0 ? allRobotStats[0] : null;
 
-  // Fetch owner info for paginated robots
-  const robotIds = paginatedStats.map(s => s.robotId);
+  // Fetch owner info for paginated robots (and top robot if not on current page)
+  const robotIdsToFetch = [...new Set([...paginatedStats.map(s => s.robotId), ...(topRobotStats ? [topRobotStats.robotId] : [])])];
   const robots = await prisma.robot.findMany({
-    where: { id: { in: robotIds } },
+    where: { id: { in: robotIdsToFetch } },
     select: { id: true, user: { select: { id: true, username: true, stableName: true } } },
   });
   const ownerMap = new Map(robots.map(r => [r.id, r.user]));
 
   const uniqueParticipants = allRobotStats.length;
-  const topRobotStats = allRobotStats.length > 0 ? allRobotStats[0] : null;
+  const topRobotOwner = topRobotStats ? ownerMap.get(topRobotStats.robotId) : null;
 
   const standings = paginatedStats.map((stats, index) => {
     const owner = ownerMap.get(stats.robotId);
@@ -175,7 +176,7 @@ async function getKothStandingsLast10({ page, limit }: { page: number; limit: nu
       totalEvents: recentMatches.length,
       uniqueParticipants,
       topRobot: topRobotStats
-        ? { id: topRobotStats.robotId, name: topRobotStats.robotName, owner: standings[0]?.owner ?? 'Unknown' }
+        ? { id: topRobotStats.robotId, name: topRobotStats.robotName, owner: topRobotOwner ? (topRobotOwner.stableName || topRobotOwner.username) : 'Unknown' }
         : null,
     },
     standings,

--- a/app/backend/src/services/koth/kothStandingsService.ts
+++ b/app/backend/src/services/koth/kothStandingsService.ts
@@ -1,4 +1,5 @@
 import prisma from '../../lib/prisma';
+import type { KothPlacement } from '../../types/battleLogTypes';
 
 interface KothStandingsParams {
   view: string;
@@ -7,6 +8,13 @@ interface KothStandingsParams {
 }
 
 export async function getKothStandings({ view, page, limit }: KothStandingsParams) {
+  if (view === 'last_10') {
+    return getKothStandingsLast10({ page, limit });
+  }
+  return getKothStandingsAllTime({ page, limit });
+}
+
+async function getKothStandingsAllTime({ page, limit }: { page: number; limit: number }) {
   const kothRobotWhere = { kothMatches: { gt: 0 }, NOT: { name: 'Bye Robot' as const } };
 
   const [totalEvents, uniqueParticipants, robots, total] = await Promise.all([
@@ -54,6 +62,124 @@ export async function getKothStandings({ view, page, limit }: KothStandingsParam
     },
     standings,
     pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
-    view,
+    view: 'all_time',
+  };
+}
+
+async function getKothStandingsLast10({ page, limit }: { page: number; limit: number }) {
+  // Get the last 10 completed KotH matches with their battle logs
+  const recentMatches = await prisma.scheduledKothMatch.findMany({
+    where: { status: 'completed', battleId: { not: null } },
+    orderBy: { scheduledFor: 'desc' },
+    take: 10,
+    select: {
+      id: true,
+      battle: {
+        select: {
+          id: true,
+          battleLog: true,
+        },
+      },
+    },
+  });
+
+  // Aggregate per-robot stats from battle log placements
+  const robotStats = new Map<number, {
+    robotId: number;
+    robotName: string;
+    wins: number;
+    matches: number;
+    totalZoneScore: number;
+    kills: number;
+    bestStreak: number;
+    currentStreak: number;
+  }>();
+
+  // Process matches in chronological order (oldest first) for streak calculation
+  const chronologicalMatches = [...recentMatches].reverse();
+
+  for (const match of chronologicalMatches) {
+    if (!match.battle?.battleLog) continue;
+
+    const log = match.battle.battleLog as unknown as { placements?: KothPlacement[] };
+    if (!log.placements) continue;
+
+    for (const placement of log.placements) {
+      let stats = robotStats.get(placement.robotId);
+      if (!stats) {
+        stats = {
+          robotId: placement.robotId,
+          robotName: placement.robotName,
+          wins: 0,
+          matches: 0,
+          totalZoneScore: 0,
+          kills: 0,
+          bestStreak: 0,
+          currentStreak: 0,
+        };
+        robotStats.set(placement.robotId, stats);
+      }
+
+      stats.matches++;
+      stats.totalZoneScore += placement.zoneScore;
+      stats.kills += placement.kills;
+
+      if (placement.placement === 1) {
+        stats.wins++;
+        stats.currentStreak++;
+        stats.bestStreak = Math.max(stats.bestStreak, stats.currentStreak);
+      } else {
+        stats.currentStreak = 0;
+      }
+    }
+  }
+
+  // Convert to array and sort by wins desc, then zone score desc
+  const allRobotStats = Array.from(robotStats.values())
+    .sort((a, b) => b.wins - a.wins || b.totalZoneScore - a.totalZoneScore);
+
+  const total = allRobotStats.length;
+  const paginatedStats = allRobotStats.slice((page - 1) * limit, page * limit);
+
+  // Fetch owner info for paginated robots
+  const robotIds = paginatedStats.map(s => s.robotId);
+  const robots = await prisma.robot.findMany({
+    where: { id: { in: robotIds } },
+    select: { id: true, user: { select: { id: true, username: true, stableName: true } } },
+  });
+  const ownerMap = new Map(robots.map(r => [r.id, r.user]));
+
+  const uniqueParticipants = allRobotStats.length;
+  const topRobotStats = allRobotStats.length > 0 ? allRobotStats[0] : null;
+
+  const standings = paginatedStats.map((stats, index) => {
+    const owner = ownerMap.get(stats.robotId);
+    return {
+      rank: (page - 1) * limit + index + 1,
+      robotId: stats.robotId,
+      robotName: stats.robotName,
+      owner: owner ? (owner.stableName || owner.username) : 'Unknown',
+      ownerId: owner?.id ?? 0,
+      kothWins: stats.wins,
+      kothMatches: stats.matches,
+      winRate: stats.matches > 0 ? Number((stats.wins / stats.matches * 100).toFixed(1)) : 0,
+      totalZoneScore: Number(stats.totalZoneScore.toFixed(1)),
+      avgZoneScore: stats.matches > 0 ? Number((stats.totalZoneScore / stats.matches).toFixed(1)) : 0,
+      kothKills: stats.kills,
+      bestStreak: stats.bestStreak,
+    };
+  });
+
+  return {
+    summary: {
+      totalEvents: recentMatches.length,
+      uniqueParticipants,
+      topRobot: topRobotStats
+        ? { id: topRobotStats.robotId, name: topRobotStats.robotName, owner: standings[0]?.owner ?? 'Unknown' }
+        : null,
+    },
+    standings,
+    pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    view: 'last_10',
   };
 }

--- a/app/frontend/src/pages/AchievementsPage.tsx
+++ b/app/frontend/src/pages/AchievementsPage.tsx
@@ -34,6 +34,8 @@ const STATUS_OPTIONS: Array<{ value: 'all' | 'locked' | 'unlocked'; label: strin
 
 const SORT_OPTIONS: Array<{ value: AchievementSortOption; label: string }> = [
   { value: 'default', label: 'Default' },
+  { value: 'date_newest', label: 'Recently Unlocked' },
+  { value: 'date_oldest', label: 'Oldest Unlocked' },
   { value: 'rarity_asc', label: 'Rarest First' },
   { value: 'rarity_desc', label: 'Most Common First' },
   { value: 'status_locked', label: 'Locked First' },

--- a/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
+++ b/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
@@ -206,7 +206,10 @@ describe('Property 13: Achievement sort correctness', () => {
         fc.array(
           fc.record({
             tier: fc.constantFrom(...TIERS),
-            unlockedAt: fc.option(fc.date({ min: new Date('2024-01-01'), max: new Date('2026-12-31') }), { nil: null }),
+            unlockedAt: fc.option(
+              fc.integer({ min: new Date('2024-01-01').getTime(), max: new Date('2026-12-31').getTime() }).map(ts => new Date(ts)),
+              { nil: null },
+            ),
           }),
           { minLength: 2, maxLength: 20 },
         ),
@@ -248,7 +251,10 @@ describe('Property 13: Achievement sort correctness', () => {
         fc.array(
           fc.record({
             tier: fc.constantFrom(...TIERS),
-            unlockedAt: fc.option(fc.date({ min: new Date('2024-01-01'), max: new Date('2026-12-31') }), { nil: null }),
+            unlockedAt: fc.option(
+              fc.integer({ min: new Date('2024-01-01').getTime(), max: new Date('2026-12-31').getTime() }).map(ts => new Date(ts)),
+              { nil: null },
+            ),
           }),
           { minLength: 2, maxLength: 20 },
         ),

--- a/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
+++ b/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
@@ -117,7 +117,7 @@ describe('Property 13: Achievement sort correctness', () => {
    * preserves all elements (same length, same IDs) — sorting is a permutation.
    */
   const SORT_OPTIONS: AchievementSortOption[] = [
-    'default', 'tier_hard', 'tier_easy', 'status_locked', 'status_unlocked',
+    'default', 'tier_hard', 'tier_easy', 'status_locked', 'status_unlocked', 'date_newest', 'date_oldest',
   ];
 
   it('sorted results preserve all elements', () => {

--- a/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
+++ b/app/frontend/src/utils/__tests__/achievementUtils.property.test.ts
@@ -199,4 +199,88 @@ describe('Property 13: Achievement sort correctness', () => {
       { numRuns: 100 },
     );
   });
+
+  it('date_newest sort places unlocked achievements before locked, ordered by timestamp descending', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            tier: fc.constantFrom(...TIERS),
+            unlockedAt: fc.option(fc.date({ min: new Date('2024-01-01'), max: new Date('2026-12-31') }), { nil: null }),
+          }),
+          { minLength: 2, maxLength: 20 },
+        ),
+        (items) => {
+          const achievements = items.map((item, i) =>
+            mockAchievement({
+              id: `T${i}`,
+              tier: item.tier,
+              unlocked: item.unlockedAt !== null,
+              unlockedAt: item.unlockedAt ? item.unlockedAt.toISOString() : null,
+            }),
+          );
+          const result = sortAchievements(achievements, 'date_newest');
+
+          // All unlocked (with unlockedAt) should come before locked (null unlockedAt)
+          const firstNullIndex = result.findIndex(a => a.unlockedAt === null);
+          if (firstNullIndex !== -1) {
+            for (let i = firstNullIndex; i < result.length; i++) {
+              expect(result[i].unlockedAt).toBeNull();
+            }
+          }
+
+          // Unlocked achievements should be in descending timestamp order
+          const unlocked = result.filter(a => a.unlockedAt !== null);
+          for (let i = 0; i < unlocked.length - 1; i++) {
+            expect(new Date(unlocked[i].unlockedAt!).getTime()).toBeGreaterThanOrEqual(
+              new Date(unlocked[i + 1].unlockedAt!).getTime(),
+            );
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('date_oldest sort places unlocked achievements before locked, ordered by timestamp ascending', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            tier: fc.constantFrom(...TIERS),
+            unlockedAt: fc.option(fc.date({ min: new Date('2024-01-01'), max: new Date('2026-12-31') }), { nil: null }),
+          }),
+          { minLength: 2, maxLength: 20 },
+        ),
+        (items) => {
+          const achievements = items.map((item, i) =>
+            mockAchievement({
+              id: `T${i}`,
+              tier: item.tier,
+              unlocked: item.unlockedAt !== null,
+              unlockedAt: item.unlockedAt ? item.unlockedAt.toISOString() : null,
+            }),
+          );
+          const result = sortAchievements(achievements, 'date_oldest');
+
+          // All unlocked (with unlockedAt) should come before locked (null unlockedAt)
+          const firstNullIndex = result.findIndex(a => a.unlockedAt === null);
+          if (firstNullIndex !== -1) {
+            for (let i = firstNullIndex; i < result.length; i++) {
+              expect(result[i].unlockedAt).toBeNull();
+            }
+          }
+
+          // Unlocked achievements should be in ascending timestamp order
+          const unlocked = result.filter(a => a.unlockedAt !== null);
+          for (let i = 0; i < unlocked.length - 1; i++) {
+            expect(new Date(unlocked[i].unlockedAt!).getTime()).toBeLessThanOrEqual(
+              new Date(unlocked[i + 1].unlockedAt!).getTime(),
+            );
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
 });

--- a/app/frontend/src/utils/achievementUtils.ts
+++ b/app/frontend/src/utils/achievementUtils.ts
@@ -52,7 +52,7 @@ export interface UnlockedAchievement {
 }
 
 export type AchievementTier = 'easy' | 'medium' | 'hard' | 'very_hard' | 'secret';
-export type AchievementSortOption = 'default' | 'rarity_asc' | 'rarity_desc' | 'status_locked' | 'status_unlocked' | 'tier_hard' | 'tier_easy';
+export type AchievementSortOption = 'default' | 'rarity_asc' | 'rarity_desc' | 'status_locked' | 'status_unlocked' | 'tier_hard' | 'tier_easy' | 'date_newest' | 'date_oldest';
 
 export interface AchievementFilters {
   tier: AchievementTier | 'all';
@@ -138,6 +138,22 @@ export function sortAchievements(
       break;
     case 'tier_easy':
       sorted.sort((a, b) => (TIER_ORDER[a.tier] ?? 0) - (TIER_ORDER[b.tier] ?? 0));
+      break;
+    case 'date_newest': // most recently unlocked first, locked achievements at the end
+      sorted.sort((a, b) => {
+        if (a.unlockedAt && b.unlockedAt) return new Date(b.unlockedAt).getTime() - new Date(a.unlockedAt).getTime();
+        if (a.unlockedAt) return -1;
+        if (b.unlockedAt) return 1;
+        return 0;
+      });
+      break;
+    case 'date_oldest': // earliest unlocked first, locked achievements at the end
+      sorted.sort((a, b) => {
+        if (a.unlockedAt && b.unlockedAt) return new Date(a.unlockedAt).getTime() - new Date(b.unlockedAt).getTime();
+        if (a.unlockedAt) return -1;
+        if (b.unlockedAt) return 1;
+        return 0;
+      });
       break;
     default:
       break;


### PR DESCRIPTION
## Summary

Fixes two player-reported issues:

### #306 — Sort achievements by achievement date
Adds **Recently Unlocked** and **Oldest Unlocked** sort options to the achievements page. Players can now quickly find achievements they just earned without scrolling through the full list. Locked achievements are pushed to the bottom when using date sorts.

**Files changed:**
- `app/frontend/src/utils/achievementUtils.ts` — new sort type + logic
- `app/frontend/src/pages/AchievementsPage.tsx` — new dropdown options
- `app/frontend/src/utils/__tests__/achievementUtils.property.test.ts` — test coverage

### #307 — KotH 'Last 10 Events' button does nothing
The backend accepted the `view=last_10` query parameter but ignored it entirely, always returning all-time cumulative stats. Now when selected, the service fetches the last 10 completed KotH matches, parses placement data from battle logs, and aggregates per-robot stats (wins, matches, zone score, kills, streak) for that window.

**Files changed:**
- `app/backend/src/services/koth/kothStandingsService.ts` — implement last_10 filtering

Closes #306, closes #307