### PR TITLE
fix: cycle scheduler resilience and tournament trigger

### DIFF
--- a/app/backend/src/routes/admin.ts
+++ b/app/backend/src/routes/admin.ts
@@ -75,12 +75,15 @@ const repairAllBodySchema = z.object({
 });
 
 const bulkCyclesBodySchema = z.object({
-  cycles: z.number().int().positive().max(100).optional().default(1),
+  cycles: z.number().int().nonnegative().max(100).optional().default(1),
   generateUsersPerCycle: z.boolean().optional().default(false),
   includeTournaments: z.boolean().optional().default(true),
   includeKoth: z.boolean().optional().default(true),
   includeDailyFinances: z.boolean().optional().default(true),
-});
+}).refine(
+  (data) => data.cycles !== 0 || data.includeTournaments,
+  { message: 'cycles=0 requires includeTournaments=true', path: ['cycles'] }
+);
 
 const battlesQuerySchema = paginationQuery.extend({
   leagueType: z.string().optional(),

--- a/app/backend/src/services/admin/adminCycleService.ts
+++ b/app/backend/src/services/admin/adminCycleService.ts
@@ -66,6 +66,105 @@ export interface BulkCycleResult {
   timestamp: string;
 }
 
+/** Result shape for tournament execution step. */
+export interface TournamentStepSummary {
+  tournamentsExecuted?: number;
+  roundsExecuted?: number;
+  matchesExecuted?: number;
+  tournamentsCompleted?: number;
+  tournamentsCreated?: number;
+  errors?: string[];
+  error?: string;
+}
+
+/**
+ * Execute tournament rounds, advance winners, and auto-create next tournament.
+ * Shared by both the cycles=0 tournament-only path and the full cycle pipeline.
+ */
+async function executeTournamentStep(): Promise<TournamentStepSummary> {
+  const summary: TournamentStepSummary = {
+    tournamentsExecuted: 0,
+    roundsExecuted: 0,
+    matchesExecuted: 0,
+    tournamentsCompleted: 0,
+    tournamentsCreated: 0,
+    errors: [],
+  };
+
+  try {
+    const activeTournaments = await getActiveTournaments();
+
+    for (const tournament of activeTournaments) {
+      try {
+        const currentRoundMatches = await getCurrentRoundMatches(tournament.id);
+
+        if (currentRoundMatches.length > 0) {
+          for (const match of currentRoundMatches) {
+            if (match.robot1Id && !match.robot2Id) {
+              await prisma.scheduledTournamentMatch.update({
+                where: { id: match.id },
+                data: {
+                  winnerId: match.robot1Id,
+                  status: 'completed',
+                  isByeMatch: true,
+                  completedAt: new Date(),
+                },
+              });
+              logger.info(`[Admin] Auto-completed bye match ${match.id} in tournament ${tournament.id}`);
+              summary.matchesExecuted!++;
+              continue;
+            }
+
+            if (!match.robot1Id && !match.robot2Id) {
+              summary.errors!.push(`Tournament ${tournament.id} Match ${match.id}: No robots assigned`);
+              continue;
+            }
+
+            try {
+              await processTournamentBattle(match);
+              summary.matchesExecuted!++;
+            } catch (error) {
+              const errorMsg = error instanceof Error ? error.message : String(error);
+              summary.errors!.push(`Tournament ${tournament.id} Match ${match.id}: ${errorMsg}`);
+            }
+          }
+
+          await advanceWinnersToNextRound(tournament.id);
+          summary.roundsExecuted!++;
+        }
+
+        summary.tournamentsExecuted!++;
+
+        const updatedTournament = await prisma.tournament.findUnique({
+          where: { id: tournament.id },
+        });
+
+        if (updatedTournament?.status === 'completed') {
+          summary.tournamentsCompleted!++;
+        }
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        summary.errors!.push(`Tournament ${tournament.id}: ${errorMsg}`);
+      }
+    }
+
+    try {
+      const nextTournament = await autoCreateNextTournament();
+      if (nextTournament) {
+        summary.tournamentsCreated!++;
+        logger.info(`[Admin] Auto-created tournament: ${nextTournament.name}`);
+      }
+    } catch (error) {
+      logger.error('[Admin] Failed to auto-create tournament:', error);
+    }
+  } catch (error) {
+    logger.error('[Admin] Tournament execution error:', error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+
+  return summary;
+}
+
 /**
  * Execute one or more complete game cycles.
  *
@@ -83,12 +182,11 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
   } = options;
 
   const maxCycles = 100;
-  const cycleCount = Math.min(Math.max(1, cycles), maxCycles);
+  const cycleCount = cycles === 0 ? 0 : Math.min(Math.max(1, cycles), maxCycles);
   const eventLogger = new EventLogger();
+  const startTime = Date.now();
 
-  logger.info(`[Admin] Running ${cycleCount} bulk cycles (includeTournaments: ${includeTournaments}, generateUsersPerCycle: ${generateUsersPerCycle})...`);
-
-  // Get or create cycle metadata (singleton pattern)
+  // Get or create cycle metadata (singleton pattern) — needed for both paths
   let cycleMetadata = await prisma.cycleMetadata.findUnique({ where: { id: 1 } });
   if (!cycleMetadata) {
     cycleMetadata = await prisma.cycleMetadata.create({
@@ -96,9 +194,31 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
     });
   }
 
+  // cycles=0 means "run only the tournament step without a full cycle"
+  if (cycleCount === 0 && includeTournaments) {
+    logger.info('[Admin] Running tournament-only execution (cycles=0)...');
+    const tournamentSummary = await executeTournamentStep();
+    const duration = Date.now() - startTime;
+
+    return {
+      success: true as const,
+      cyclesCompleted: 0,
+      totalCyclesInSystem: cycleMetadata.totalCycles,
+      includeTournaments: true,
+      includeKoth: false,
+      includeDailyFinances: false,
+      generateUsersPerCycleEnabled: false,
+      totalDuration: duration,
+      averageCycleDuration: 0,
+      results: [{ cycle: 0, tournaments: tournamentSummary, duration }],
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  logger.info(`[Admin] Running ${cycleCount} bulk cycles (includeTournaments: ${includeTournaments}, generateUsersPerCycle: ${generateUsersPerCycle})...`);
+
   let currentCycleNumber = cycleMetadata.totalCycles;
   const cycleResults: CycleResult[] = [];
-  const startTime = Date.now();
 
   for (let i = 1; i <= cycleCount; i++) {
     const cycleStart = Date.now();
@@ -243,89 +363,8 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
       const step5Start = Date.now();
       let tournamentSummary = null;
       if (includeTournaments) {
-        try {
-          tournamentSummary = {
-            tournamentsExecuted: 0,
-            roundsExecuted: 0,
-            matchesExecuted: 0,
-            tournamentsCompleted: 0,
-            tournamentsCreated: 0,
-            errors: [] as string[],
-          };
-
-          const activeTournaments = await getActiveTournaments();
-
-          for (const tournament of activeTournaments) {
-            try {
-              const currentRoundMatches = await getCurrentRoundMatches(tournament.id);
-
-              if (currentRoundMatches.length > 0) {
-                for (const match of currentRoundMatches) {
-                  if (match.robot1Id && !match.robot2Id) {
-                    await prisma.scheduledTournamentMatch.update({
-                      where: { id: match.id },
-                      data: {
-                        winnerId: match.robot1Id,
-                        status: 'completed',
-                        isByeMatch: true,
-                        completedAt: new Date(),
-                      },
-                    });
-                    logger.info(`[Admin] Auto-completed bye match ${match.id} in tournament ${tournament.id}`);
-                    tournamentSummary.matchesExecuted++;
-                    continue;
-                  }
-
-                  if (!match.robot1Id && !match.robot2Id) {
-                    tournamentSummary.errors.push(`Tournament ${tournament.id} Match ${match.id}: No robots assigned`);
-                    continue;
-                  }
-
-                  try {
-                    await processTournamentBattle(match);
-                    tournamentSummary.matchesExecuted++;
-                  } catch (error) {
-                    const errorMsg = error instanceof Error ? error.message : String(error);
-                    tournamentSummary.errors.push(`Tournament ${tournament.id} Match ${match.id}: ${errorMsg}`);
-                  }
-                }
-
-                await advanceWinnersToNextRound(tournament.id);
-                tournamentSummary.roundsExecuted++;
-              }
-
-              tournamentSummary.tournamentsExecuted++;
-
-              const updatedTournament = await prisma.tournament.findUnique({
-                where: { id: tournament.id },
-              });
-
-              if (updatedTournament?.status === 'completed') {
-                tournamentSummary.tournamentsCompleted++;
-              }
-            } catch (error) {
-              const errorMsg = error instanceof Error ? error.message : String(error);
-              tournamentSummary.errors.push(`Tournament ${tournament.id}: ${errorMsg}`);
-            }
-          }
-
-          try {
-            const nextTournament = await autoCreateNextTournament();
-            if (nextTournament) {
-              tournamentSummary.tournamentsCreated++;
-              logger.info(`[Admin] Auto-created tournament: ${nextTournament.name}`);
-            }
-          } catch (error) {
-            logger.error('[Admin] Failed to auto-create tournament:', error);
-          }
-
-          logger.info(`[Admin] Tournaments: ${tournamentSummary.tournamentsExecuted} executed, ${tournamentSummary.roundsExecuted} rounds, ${tournamentSummary.matchesExecuted} matches`);
-        } catch (error) {
-          logger.error('[Admin] Tournament execution error:', error);
-          tournamentSummary = {
-            error: error instanceof Error ? error.message : String(error),
-          };
-        }
+        tournamentSummary = await executeTournamentStep();
+        logger.info(`[Admin] Tournaments: ${tournamentSummary.tournamentsExecuted || 0} executed, ${tournamentSummary.roundsExecuted || 0} rounds, ${tournamentSummary.matchesExecuted || 0} matches`);
       }
       await eventLogger.logCycleStepComplete(
         currentCycleNumber,

--- a/app/backend/src/services/league/leagueBattleOrchestrator.ts
+++ b/app/backend/src/services/league/leagueBattleOrchestrator.ts
@@ -601,50 +601,55 @@ export async function processBattle(scheduledMatch: ScheduledLeagueMatch): Promi
   const robot2IsWinner = result.winnerId === robot2.id;
   
   // Log battle_complete events to audit log - ONE EVENT PER ROBOT (parallel — independent writes)
-  await Promise.all([
-    logBattleAuditEvent(
-      {
-        robotId: robot1.id,
-        userId: robot1.userId,
-        isWinner: robot1IsWinner,
-        isDraw: result.isDraw,
-        damageDealt: robot1Participant.damageDealt,
-        finalHP: robot1Participant.finalHP,
-        yielded: robot1Participant.yielded,
-        destroyed: robot1Participant.destroyed,
-        credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-        prestige: stats1.prestigeAwarded,
-        fame: stats1.fameAwarded,
-        eloBefore: robot1Participant.eloBefore,
-        eloAfter: robot1Participant.eloAfter,
-      },
-      { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-      robot2.id,
-      streamingRevenue1?.totalRevenue || 0,
-      result.isByeMatch,
-    ),
-    logBattleAuditEvent(
-      {
-        robotId: robot2.id,
-        userId: robot2.userId,
-        isWinner: robot2IsWinner,
-        isDraw: result.isDraw,
-        damageDealt: robot2Participant.damageDealt,
-        finalHP: robot2Participant.finalHP,
-        yielded: robot2Participant.yielded,
-        destroyed: robot2Participant.destroyed,
-        credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-        prestige: stats2.prestigeAwarded,
-        fame: stats2.fameAwarded,
-        eloBefore: robot2Participant.eloBefore,
-        eloAfter: robot2Participant.eloAfter,
-      },
-      { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-      robot1.id,
-      streamingRevenue2?.totalRevenue || 0,
-      result.isByeMatch,
-    ),
-  ]);
+  // Non-blocking: audit failures must never crash a battle
+  try {
+    await Promise.all([
+      logBattleAuditEvent(
+        {
+          robotId: robot1.id,
+          userId: robot1.userId,
+          isWinner: robot1IsWinner,
+          isDraw: result.isDraw,
+          damageDealt: robot1Participant.damageDealt,
+          finalHP: robot1Participant.finalHP,
+          yielded: robot1Participant.yielded,
+          destroyed: robot1Participant.destroyed,
+          credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+          prestige: stats1.prestigeAwarded,
+          fame: stats1.fameAwarded,
+          eloBefore: robot1Participant.eloBefore,
+          eloAfter: robot1Participant.eloAfter,
+        },
+        { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+        robot2.id,
+        streamingRevenue1?.totalRevenue || 0,
+        result.isByeMatch,
+      ),
+      logBattleAuditEvent(
+        {
+          robotId: robot2.id,
+          userId: robot2.userId,
+          isWinner: robot2IsWinner,
+          isDraw: result.isDraw,
+          damageDealt: robot2Participant.damageDealt,
+          finalHP: robot2Participant.finalHP,
+          yielded: robot2Participant.yielded,
+          destroyed: robot2Participant.destroyed,
+          credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+          prestige: stats2.prestigeAwarded,
+          fame: stats2.fameAwarded,
+          eloBefore: robot2Participant.eloBefore,
+          eloAfter: robot2Participant.eloAfter,
+        },
+        { id: battle.id, battleType: battle.battleType, leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+        robot1.id,
+        streamingRevenue2?.totalRevenue || 0,
+        result.isByeMatch,
+      ),
+    ]);
+  } catch (auditError) {
+    logger.error(`[BattleOrchestrator] Audit log failed for battle #${battle.id}: ${auditError instanceof Error ? auditError.message : String(auditError)}`);
+  }
   
   // Prestige/fame awards are already stored in BattleParticipant records
   // No need to update Battle table

--- a/app/backend/src/services/tag-team/tagTeamBattleOrchestrator.ts
+++ b/app/backend/src/services/tag-team/tagTeamBattleOrchestrator.ts
@@ -2096,26 +2096,33 @@ async function updateTagTeamBattleResults(
       },
     ];
 
+    // Non-blocking: audit failures must never crash a battle
+    let auditSuccessCount = 0;
     for (const r of tagTeamAuditRobots) {
-      await logBattleAuditEvent(
-        {
-          robotId: r.robotId, userId: r.userId,
-          isWinner: r.isWinner, isDraw: r.isDraw,
-          damageDealt: r.damageDealt, finalHP: r.finalHP,
-          yielded: r.yielded, destroyed: r.destroyed,
-          credits: r.credits, prestige: r.prestige, fame: r.fame,
-          eloBefore: r.eloBefore, eloAfter: r.eloAfter,
-        },
-        { id: battle.id, battleType: 'tag_team', leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-        null, // Tag team has no single opponent
-        r.streamingRevenue,
-        false,
-        r.extras,
-      );
+      try {
+        await logBattleAuditEvent(
+          {
+            robotId: r.robotId, userId: r.userId,
+            isWinner: r.isWinner, isDraw: r.isDraw,
+            damageDealt: r.damageDealt, finalHP: r.finalHP,
+            yielded: r.yielded, destroyed: r.destroyed,
+            credits: r.credits, prestige: r.prestige, fame: r.fame,
+            eloBefore: r.eloBefore, eloAfter: r.eloAfter,
+          },
+          { id: battle.id, battleType: 'tag_team', leagueType: battle.leagueType, durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+          null, // Tag team has no single opponent
+          r.streamingRevenue,
+          false,
+          r.extras,
+        );
+        auditSuccessCount++;
+      } catch (auditError) {
+        logger.error(`[TagTeamBattles] Audit log failed for robot ${r.robotId} in battle #${battle.id}: ${auditError instanceof Error ? auditError.message : String(auditError)}`);
+      }
     }
     
     logger.info(
-      `[TagTeamBattles] Created 4 audit log events for tag team battle ${battle.id} ` +
+      `[TagTeamBattles] Created ${auditSuccessCount}/4 audit log events for tag team battle ${battle.id} ` +
       `(one per robot, rewards split 50/50 per team)`
     );
 

--- a/app/backend/src/services/tournament/tournamentBattleOrchestrator.ts
+++ b/app/backend/src/services/tournament/tournamentBattleOrchestrator.ts
@@ -203,50 +203,59 @@ export async function processTournamentBattle(
   const isDraw = battle.winnerId === null;
   
   // Event 1: Robot 1's perspective
-  await logBattleAuditEvent(
-    {
-      robotId: robot1.id,
-      userId: robot1.userId,
-      isWinner: robot1IsWinner,
-      isDraw,
-      damageDealt: robot1Participant.damageDealt,
-      finalHP: robot1Participant.finalHP,
-      yielded: robot1Participant.yielded,
-      destroyed: robot1Participant.destroyed,
-      credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-      prestige: stats1.prestigeAwarded,
-      fame: stats1.fameAwarded,
-      eloBefore: robot1Participant.eloBefore,
-      eloAfter: robot1Participant.eloAfter,
-    },
-    { id: battle.id, battleType: 'tournament', leagueType: 'tournament', durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-    robot2.id,
-    streamingRevenue1?.totalRevenue || 0,
-    false,
-  );
-  
   // Event 2: Robot 2's perspective
-  await logBattleAuditEvent(
-    {
-      robotId: robot2.id,
-      userId: robot2.userId,
-      isWinner: robot2IsWinner,
-      isDraw,
-      damageDealt: robot2Participant.damageDealt,
-      finalHP: robot2Participant.finalHP,
-      yielded: robot2Participant.yielded,
-      destroyed: robot2Participant.destroyed,
-      credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
-      prestige: stats2.prestigeAwarded,
-      fame: stats2.fameAwarded,
-      eloBefore: robot2Participant.eloBefore,
-      eloAfter: robot2Participant.eloAfter,
-    },
-    { id: battle.id, battleType: 'tournament', leagueType: 'tournament', durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
-    robot1.id,
-    streamingRevenue2?.totalRevenue || 0,
-    false,
-  );
+  // Non-blocking: audit failures must never crash a battle
+  try {
+    await logBattleAuditEvent(
+      {
+        robotId: robot1.id,
+        userId: robot1.userId,
+        isWinner: robot1IsWinner,
+        isDraw,
+        damageDealt: robot1Participant.damageDealt,
+        finalHP: robot1Participant.finalHP,
+        yielded: robot1Participant.yielded,
+        destroyed: robot1Participant.destroyed,
+        credits: robot1IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+        prestige: stats1.prestigeAwarded,
+        fame: stats1.fameAwarded,
+        eloBefore: robot1Participant.eloBefore,
+        eloAfter: robot1Participant.eloAfter,
+      },
+      { id: battle.id, battleType: 'tournament', leagueType: 'tournament', durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+      robot2.id,
+      streamingRevenue1?.totalRevenue || 0,
+      false,
+    );
+  } catch (auditError) {
+    logger.error(`[TournamentBattleOrchestrator] Audit log failed for robot ${robot1.id} in battle #${battle.id}: ${auditError instanceof Error ? auditError.message : String(auditError)}`);
+  }
+
+  try {
+    await logBattleAuditEvent(
+      {
+        robotId: robot2.id,
+        userId: robot2.userId,
+        isWinner: robot2IsWinner,
+        isDraw,
+        damageDealt: robot2Participant.damageDealt,
+        finalHP: robot2Participant.finalHP,
+        yielded: robot2Participant.yielded,
+        destroyed: robot2Participant.destroyed,
+        credits: robot2IsWinner ? (battle.winnerReward ?? 0) : (battle.loserReward ?? 0),
+        prestige: stats2.prestigeAwarded,
+        fame: stats2.fameAwarded,
+        eloBefore: robot2Participant.eloBefore,
+        eloAfter: robot2Participant.eloAfter,
+      },
+      { id: battle.id, battleType: 'tournament', leagueType: 'tournament', durationSeconds: battle.durationSeconds, eloChange: battle.eloChange },
+      robot1.id,
+      streamingRevenue2?.totalRevenue || 0,
+      false,
+    );
+  } catch (auditError) {
+    logger.error(`[TournamentBattleOrchestrator] Audit log failed for robot ${robot2.id} in battle #${battle.id}: ${auditError instanceof Error ? auditError.message : String(auditError)}`);
+  }
 
   // Update tournament match with result
   await prisma.scheduledTournamentMatch.update({

--- a/app/frontend/src/pages/admin/CycleControlsPage.tsx
+++ b/app/frontend/src/pages/admin/CycleControlsPage.tsx
@@ -514,7 +514,16 @@ function SchedulerStatusPanel({ status }: { status: SchedulerState | null }) {
                   <td className="px-4 py-3 text-secondary">{job.lastRunAt ? new Date(job.lastRunAt).toLocaleString() : '—'}</td>
                   <td className="px-4 py-3">
                     {job.lastRunStatus === 'success' && <span className="text-success">✓ Success</span>}
-                    {job.lastRunStatus === 'failed' && <span className="text-error">✗ Failed</span>}
+                    {job.lastRunStatus === 'failed' && (
+                      <span className="text-error" title={job.lastError || undefined}>
+                        ✗ Failed
+                        {job.lastError && (
+                          <span className="block text-xs text-error/70 mt-0.5 max-w-[300px] truncate">
+                            {job.lastError}
+                          </span>
+                        )}
+                      </span>
+                    )}
                     {!job.lastRunStatus && <span className="text-secondary">—</span>}
                   </td>
                   <td className="px-4 py-3 text-secondary">{job.lastRunDurationMs != null ? `${(job.lastRunDurationMs / 1000).toFixed(2)}s` : '—'}</td>


### PR DESCRIPTION
- Wrap logBattleAuditEvent in try/catch across league, tournament, and tag-team orchestrators so audit log unique constraint violations never crash battles
- Allow cycles=0 in bulk cycles schema (nonnegative instead of positive)
- Add tournament-only execution path for cycles=0 with includeTournaments
- Display lastError in admin scheduler status table for failed jobs