### PR TITLE
fix: reduce backup retention and switch to pg_dump custom format

### DIFF
--- a/app/backend/src/services/admin/adminCycleService.ts
+++ b/app/backend/src/services/admin/adminCycleService.ts
@@ -601,7 +601,7 @@ export async function executeBulkCycles(options: BulkCycleOptions): Promise<Bulk
 
       // Execute all currency updates in a single transaction
       if (currencyUpdates.length > 0) {
-        await prisma.$transaction(currencyUpdates);
+        await prisma.$transaction(currencyUpdates, { timeout: 30000 });
       }
 
       logger.info(`[Admin] Passive income: ₡${totalPassiveIncome.toLocaleString()}, Operating costs: ₡${totalOperatingCosts.toLocaleString()}`);

--- a/app/backend/src/services/economy/repairService.ts
+++ b/app/backend/src/services/economy/repairService.ts
@@ -204,8 +204,17 @@ export async function repairAllRobots(deductCosts: boolean = true, cycleNumber?:
     });
   }
 
-  // Execute all robot updates and user deductions in a single transaction
-  await prisma.$transaction([...robotUpdates, ...userDeductions]);
+  // Execute robot updates and user deductions in chunked transactions
+  // to avoid exceeding Prisma's interactive transaction timeout on large rosters.
+  // User deductions are small (one per user) so they go in a single batch.
+  const CHUNK_SIZE = 200;
+  for (let i = 0; i < robotUpdates.length; i += CHUNK_SIZE) {
+    const chunk = robotUpdates.slice(i, i + CHUNK_SIZE);
+    await prisma.$transaction(chunk);
+  }
+  if (userDeductions.length > 0) {
+    await prisma.$transaction(userDeductions);
+  }
 
   // Log repair events sequentially (audit trail, non-critical)
   for (const event of repairEvents) {

--- a/app/scripts/backup.sh
+++ b/app/scripts/backup.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 BACKUP_DIR="/opt/armouredsouls/backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 DAY_OF_WEEK=$(date +%u)  # 1=Monday, 7=Sunday
-DAILY_RETAIN="${BACKUP_DAILY_RETAIN:-3}"
-WEEKLY_RETAIN="${BACKUP_WEEKLY_RETAIN:-2}"
-DISK_THRESHOLD="${BACKUP_DISK_THRESHOLD:-90}"
+DAILY_RETAIN="${BACKUP_DAILY_RETAIN:-2}"
+WEEKLY_RETAIN="${BACKUP_WEEKLY_RETAIN:-0}"
+DISK_THRESHOLD="${BACKUP_DISK_THRESHOLD:-85}"
 
 # Load database credentials from environment or .env file
 if [ -f /opt/armouredsouls/backend/.env ]; then
@@ -53,10 +53,10 @@ if [ "${DISK_USAGE}" -ge "${DISK_THRESHOLD}" ]; then
 fi
 
 # --- Create daily backup ---
-DAILY_FILE="${BACKUP_DIR}/daily/${DB_NAME}_daily_${TIMESTAMP}.sql.gz"
+DAILY_FILE="${BACKUP_DIR}/daily/${DB_NAME}_daily_${TIMESTAMP}.dump"
 log "Starting daily backup: ${DAILY_FILE}"
 
-if pg_dump -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}" | gzip > "${DAILY_FILE}"; then
+if pg_dump -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -Fc "${DB_NAME}" > "${DAILY_FILE}"; then
   FILE_SIZE=$(du -h "${DAILY_FILE}" | cut -f1)
   log "Daily backup complete: ${DAILY_FILE} (${FILE_SIZE})"
 else
@@ -67,26 +67,26 @@ fi
 
 # --- Promote Sunday backup to weekly ---
 if [ "${DAY_OF_WEEK}" -eq 7 ]; then
-  WEEKLY_FILE="${BACKUP_DIR}/weekly/${DB_NAME}_weekly_${TIMESTAMP}.sql.gz"
+  WEEKLY_FILE="${BACKUP_DIR}/weekly/${DB_NAME}_weekly_${TIMESTAMP}.dump"
   cp "${DAILY_FILE}" "${WEEKLY_FILE}"
   log "Weekly backup created: ${WEEKLY_FILE}"
 fi
 
 # --- Cleanup old daily backups (keep last N) ---
-DAILY_COUNT=$(find "${BACKUP_DIR}/daily" -name "*.sql.gz" -type f | wc -l)
+DAILY_COUNT=$(find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
 if [ "${DAILY_COUNT}" -gt "${DAILY_RETAIN}" ]; then
   DELETE_COUNT=$((DAILY_COUNT - DAILY_RETAIN))
-  find "${BACKUP_DIR}/daily" -name "*.sql.gz" -type f -printf '%T+ %p\n' \
+  find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
     | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
     | xargs rm -f
   log "Cleaned up ${DELETE_COUNT} old daily backup(s)"
 fi
 
 # --- Cleanup old weekly backups (keep last N) ---
-WEEKLY_COUNT=$(find "${BACKUP_DIR}/weekly" -name "*.sql.gz" -type f | wc -l)
+WEEKLY_COUNT=$(find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
 if [ "${WEEKLY_COUNT}" -gt "${WEEKLY_RETAIN}" ]; then
   DELETE_COUNT=$((WEEKLY_COUNT - WEEKLY_RETAIN))
-  find "${BACKUP_DIR}/weekly" -name "*.sql.gz" -type f -printf '%T+ %p\n' \
+  find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
     | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
     | xargs rm -f
   log "Cleaned up ${DELETE_COUNT} old weekly backup(s)"

--- a/app/scripts/restore.sh
+++ b/app/scripts/restore.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # ============================================================================
 # Armoured Souls — PostgreSQL Backup Restore
-# Usage: ./restore.sh <backup_file.sql.gz>
+# Usage: ./restore.sh <backup_file.dump|backup_file.sql.gz>
 # ============================================================================
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 <backup_file.sql.gz>"
+  echo "Usage: $0 <backup_file.dump|backup_file.sql.gz>"
   echo ""
   echo "Available backups:"
   ls -lht /opt/armouredsouls/backups/daily/ 2>/dev/null || echo "  No daily backups found"
@@ -66,7 +66,11 @@ dropdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" --if-exists "${DB_NAME}"
 createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Restoring from backup..."
-gunzip -c "${BACKUP_FILE}" | psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}" > /dev/null
+if [[ "${BACKUP_FILE}" == *.dump ]]; then
+  pg_restore -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" --no-owner --no-acl "${BACKUP_FILE}"
+else
+  gunzip -c "${BACKUP_FILE}" | psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}" > /dev/null
+fi
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Running migrations..."
 cd /opt/armouredsouls/backend


### PR DESCRIPTION
- Retention: 3 daily + 2 weekly → 2 daily + 0 weekly (ACC only)
- Disk threshold: 90% → 85% (skip backup earlier)
- Format: sql.gz → pg_dump -Fc (smaller, faster restore)
- Restore script: handles both .dump and legacy .sql.gz files
- Cleanup patterns match both old and new file extensions