### PR TITLE
fix(deploy): make logrotate install non-blocking when sudo lacks NOPASSWD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -490,15 +490,25 @@ jobs:
           CHANGELOG_DEPLOY_TOKEN: ${{ secrets.CHANGELOG_DEPLOY_TOKEN }}
 
       - name: Ensure logrotate config
+        continue-on-error: true
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.ACC_VPS_IP }}
           username: ${{ secrets.ACC_VPS_USER }}
           key: ${{ secrets.ACC_SSH_KEY }}
           script: |
-            sudo cp /opt/armouredsouls/scripts/logrotate-armouredsouls.conf /etc/logrotate.d/armouredsouls
-            sudo chown root:root /etc/logrotate.d/armouredsouls
-            sudo chmod 644 /etc/logrotate.d/armouredsouls
+            # Install logrotate config if it differs from the repo version
+            REPO_CONF="/opt/armouredsouls/scripts/logrotate-armouredsouls.conf"
+            SYSTEM_CONF="/etc/logrotate.d/armouredsouls"
+            if [ -f "$REPO_CONF" ] && ! diff -q "$REPO_CONF" "$SYSTEM_CONF" > /dev/null 2>&1; then
+              echo "logrotate config changed — installing"
+              sudo cp "$REPO_CONF" "$SYSTEM_CONF" \
+                && sudo chown root:root "$SYSTEM_CONF" \
+                && sudo chmod 644 "$SYSTEM_CONF" \
+                || echo "WARNING: logrotate install failed — sudo may need passwordless config for deploy user (cp/chown/chmod on /etc/logrotate.d/armouredsouls)"
+            else
+              echo "logrotate config unchanged — skipping"
+            fi
 
       - name: Restart backend via PM2
         uses: appleboy/ssh-action@v1
@@ -774,15 +784,25 @@ jobs:
           CHANGELOG_DEPLOY_TOKEN: ${{ secrets.CHANGELOG_DEPLOY_TOKEN }}
 
       - name: Ensure logrotate config
+        continue-on-error: true
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.PRD_VPS_IP }}
           username: ${{ secrets.PRD_VPS_USER }}
           key: ${{ secrets.PRD_SSH_KEY }}
           script: |
-            sudo cp /opt/armouredsouls/scripts/logrotate-armouredsouls.conf /etc/logrotate.d/armouredsouls
-            sudo chown root:root /etc/logrotate.d/armouredsouls
-            sudo chmod 644 /etc/logrotate.d/armouredsouls
+            # Install logrotate config if it differs from the repo version
+            REPO_CONF="/opt/armouredsouls/scripts/logrotate-armouredsouls.conf"
+            SYSTEM_CONF="/etc/logrotate.d/armouredsouls"
+            if [ -f "$REPO_CONF" ] && ! diff -q "$REPO_CONF" "$SYSTEM_CONF" > /dev/null 2>&1; then
+              echo "logrotate config changed — installing"
+              sudo cp "$REPO_CONF" "$SYSTEM_CONF" \
+                && sudo chown root:root "$SYSTEM_CONF" \
+                && sudo chmod 644 "$SYSTEM_CONF" \
+                || echo "WARNING: logrotate install failed — sudo may need passwordless config for deploy user (cp/chown/chmod on /etc/logrotate.d/armouredsouls)"
+            else
+              echo "logrotate config unchanged — skipping"
+            fi
 
       - name: Restart backend via PM2
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## Problem

Deploy to ACC failed on the new "Ensure logrotate config" step (introduced in #320) with:

```
sudo: a terminal is required to read the password
sudo: a password is required
```

The deploy user can run `sudo` for the specific Caddy commands but doesn't have generic passwordless sudo, so `sudo cp`/`sudo chown`/`sudo chmod` on `/etc/logrotate.d/armouredsouls` fails.

## Fix

Match the existing Caddy reload pattern:
- Add `continue-on-error: true` so a sudoers misconfiguration doesn't fail the deploy.
- Wrap the sudo chain in `|| echo "WARNING ..."` so the script itself returns 0.
- Add a `diff -q` idempotence check so we only attempt the install when the config actually changed (mirrors the existing Caddyfile sync logic).

Same change applied to both the ACC and PRD branches of the workflow.

## Follow-up needed on the VPS

For the install to actually take effect, the deploy user needs a sudoers entry like:

```
deploy ALL=(root) NOPASSWD: /usr/bin/cp /opt/armouredsouls/scripts/logrotate-armouredsouls.conf /etc/logrotate.d/armouredsouls, /usr/bin/chown root\:root /etc/logrotate.d/armouredsouls, /usr/bin/chmod 644 /etc/logrotate.d/armouredsouls
```

Until that's added, the WARNING will appear in the step output but the deploy succeeds. The file can also be installed once manually with `sudo`.

## Verification

Bash syntax checked. The change is workflow-only — no application code touched.

The two failing weapon-shop e2e tests in the previous run (`should filter weapons by loadout type`, `should open weapon detail modal`) are unrelated to this PR — they were already flaky on main and need a separate ticket.