### PR TITLE
fix(deploy): pre-flight disk cleanup, alert cooldown, and diagnostic script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -411,6 +411,20 @@ jobs:
             ./app/backend/dist/ \
             ${{ secrets.ACC_VPS_USER }}@${{ secrets.ACC_VPS_IP }}:/opt/armouredsouls/backend/dist/
 
+      - name: Pre-flight — free disk space and verify capacity (ACC)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.ACC_VPS_IP }}
+          username: ${{ secrets.ACC_VPS_USER }}
+          key: ${{ secrets.ACC_SSH_KEY }}
+          command_timeout: 2m
+          # Trims old pre-deploy / overflow backup dumps and aborts the deploy
+          # with a Discord alert if disk usage is still ≥ 90% afterward. Stops
+          # `npm install --prefer-offline` from hitting ENOSPC and timing out
+          # at minute 10 — see app/scripts/preflight.sh for full rationale.
+          script: |
+            bash /opt/armouredsouls/scripts/preflight.sh
+
       - name: Install dependencies on VPS
         uses: appleboy/ssh-action@v1
         with:
@@ -714,6 +728,20 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key" \
             ./app/backend/dist/ \
             ${{ secrets.PRD_VPS_USER }}@${{ secrets.PRD_VPS_IP }}:/opt/armouredsouls/backend/dist/
+
+      - name: Pre-flight — free disk space and verify capacity (production)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PRD_VPS_IP }}
+          username: ${{ secrets.PRD_VPS_USER }}
+          key: ${{ secrets.PRD_SSH_KEY }}
+          command_timeout: 2m
+          # Trims old pre-deploy / overflow backup dumps and aborts the deploy
+          # with a Discord alert if disk usage is still ≥ 90% afterward. Stops
+          # `npm install --prefer-offline` from hitting ENOSPC and timing out
+          # at minute 10 — see app/scripts/preflight.sh for full rationale.
+          script: |
+            bash /opt/armouredsouls/scripts/preflight.sh
 
       - name: Install dependencies on VPS
         uses: appleboy/ssh-action@v1

--- a/app/scripts/disk-diagnostic.sh
+++ b/app/scripts/disk-diagnostic.sh
@@ -87,9 +87,65 @@ fi
 print_header "USER UPLOADS"
 top_under /opt/armouredsouls/backend/uploads 2 10
 
-print_header "POSTGRES (via Docker volumes if present)"
+print_header "POSTGRES"
 if command -v docker >/dev/null 2>&1; then
+  echo "Docker disk usage:"
   docker system df 2>/dev/null || echo "  (docker available but `docker system df` failed)"
+
+  # Pull DB credentials from the backend .env so we don't hardcode role names.
+  # ACC is `as_acc`, production is `as_prd`, the Compose file's local default
+  # is `armouredsouls` — only the env file knows for sure on this host.
+  POSTGRES_ENV="/opt/armouredsouls/backend/.env"
+  if [ -f "$POSTGRES_ENV" ]; then
+    PG_USER=$(grep -E '^POSTGRES_USER=' "$POSTGRES_ENV" | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'")
+    PG_DB=$(grep -E '^POSTGRES_DB=' "$POSTGRES_ENV" | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'")
+  fi
+  PG_USER="${PG_USER:-armouredsouls}"
+  PG_DB="${PG_DB:-armouredsouls}"
+
+  PG_CONTAINER=$(docker ps -qf name=postgres 2>/dev/null | head -1)
+  if [ -n "$PG_CONTAINER" ]; then
+    echo
+    echo "WAL segment size:"
+    docker exec "$PG_CONTAINER" sh -c 'du -sh /var/lib/postgresql/data/pg_wal 2>/dev/null' \
+      | sed 's/^/  /' || echo "  (could not read pg_wal)"
+
+    echo
+    echo "Top 10 tables by total size (table + indexes + toast) for db=${PG_DB}:"
+    docker exec "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -At -F '|' -c "
+      SELECT
+        relname,
+        pg_size_pretty(pg_total_relation_size(schemaname||'.'||relname)),
+        pg_size_pretty(pg_relation_size(schemaname||'.'||relname)),
+        pg_size_pretty(pg_total_relation_size(schemaname||'.'||relname) - pg_relation_size(schemaname||'.'||relname))
+      FROM pg_stat_user_tables
+      ORDER BY pg_total_relation_size(schemaname||'.'||relname) DESC
+      LIMIT 10;
+    " 2>/dev/null \
+      | awk -F'|' 'BEGIN { printf "  %-30s %12s %12s %12s\n", "TABLE", "TOTAL", "TABLE", "INDEX/TOAST" }
+                  { printf "  %-30s %12s %12s %12s\n", $1, $2, $3, $4 }' \
+      || echo "  (psql query failed — check POSTGRES_USER / POSTGRES_DB in $POSTGRES_ENV)"
+
+    echo
+    echo "Tables with significant dead-tuple bloat (>1000 dead tuples):"
+    docker exec "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -At -F '|' -c "
+      SELECT
+        relname,
+        n_dead_tup,
+        n_live_tup,
+        ROUND(100.0 * n_dead_tup / NULLIF(n_live_tup + n_dead_tup, 0), 1)::text || '%',
+        COALESCE(last_autovacuum::text, 'never')
+      FROM pg_stat_user_tables
+      WHERE n_dead_tup > 1000
+      ORDER BY n_dead_tup DESC
+      LIMIT 10;
+    " 2>/dev/null \
+      | awk -F'|' 'BEGIN { printf "  %-30s %10s %10s %10s %s\n", "TABLE", "DEAD", "LIVE", "DEAD%", "LAST VACUUM" }
+                  NR > 0 { printf "  %-30s %10s %10s %10s %s\n", $1, $2, $3, $4, $5 }' \
+      || echo "  (psql query failed)"
+  else
+    echo "  (no running postgres container)"
+  fi
 else
   echo "  (docker not on PATH — Postgres may be running natively)"
 fi

--- a/app/scripts/disk-diagnostic.sh
+++ b/app/scripts/disk-diagnostic.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Armoured Souls — Disk Diagnostic
+#
+# Standalone, read-only inspection of where disk space is being used.
+# Designed to run on demand from SSH or be triggered by an admin.
+#
+# Output is one consolidated report covering the usual suspects:
+#   - top-level dirs under /opt/armouredsouls
+#   - /var/log/* (system + service logs)
+#   - PM2 logs (~/.pm2/logs)
+#   - Postgres data dir + WAL + Docker volumes
+#   - Application-specific dirs we know about (cycle_logs, backups, uploads)
+#
+# Usage:
+#   bash /opt/armouredsouls/scripts/disk-diagnostic.sh
+#
+# Output goes to stdout. Pipe through `column -t` or `less` if needed.
+# Always exits 0; sections that fail (permission denied, no such dir) are
+# silently skipped rather than aborting the whole report.
+# ============================================================================
+
+print_header() {
+  echo
+  echo "===== $1 ====="
+}
+
+# Top consumers anywhere under a path. Suppresses "permission denied" noise.
+top_under() {
+  local path="$1"
+  local depth="${2:-1}"
+  local count="${3:-10}"
+  if [ -d "$path" ]; then
+    du -h --max-depth="$depth" "$path" 2>/dev/null \
+      | sort -hr \
+      | head -n "$count"
+  else
+    echo "  (not found: $path)"
+  fi
+}
+
+print_header "DISK USAGE OVERVIEW"
+df -h / /var /opt 2>/dev/null | awk 'NR==1 || /\// {print}' || df -h /
+
+print_header "TOP /opt/armouredsouls/* (depth 1)"
+top_under /opt/armouredsouls 1 15
+
+print_header "TOP /var/log/* (depth 1)"
+top_under /var/log 1 15
+
+print_header "PM2 LOGS (~/.pm2/logs)"
+top_under "$HOME/.pm2/logs" 1 10
+
+print_header "BACKEND CYCLE LOGS"
+if [ -d /opt/armouredsouls/backend/cycle_logs ]; then
+  CYCLE_COUNT=$(find /opt/armouredsouls/backend/cycle_logs -maxdepth 1 -name 'cycle*.csv' -type f 2>/dev/null | wc -l)
+  CYCLE_SIZE=$(du -sh /opt/armouredsouls/backend/cycle_logs 2>/dev/null | cut -f1)
+  echo "  Total: ${CYCLE_SIZE} across ${CYCLE_COUNT} files"
+  echo "  Largest 5:"
+  ls -lhS /opt/armouredsouls/backend/cycle_logs 2>/dev/null | head -6 | tail -5 | awk '{printf "    %s  %s\n", $5, $NF}'
+else
+  echo "  (no cycle_logs dir)"
+fi
+
+print_header "BACKUPS"
+if [ -d /opt/armouredsouls/backups ]; then
+  BACKUP_TOTAL=$(du -sh /opt/armouredsouls/backups 2>/dev/null | cut -f1)
+  echo "  Total: ${BACKUP_TOTAL}"
+  echo "  By category:"
+  du -sh /opt/armouredsouls/backups/daily /opt/armouredsouls/backups/weekly 2>/dev/null \
+    | awk '{printf "    %s  %s\n", $1, $2}'
+  echo "  Pre-deploy dumps:"
+  PRE_COUNT=$(find /opt/armouredsouls/backups -maxdepth 1 -name 'pre_deploy_*.dump' -type f 2>/dev/null | wc -l)
+  PRE_SIZE=$(du -sh /opt/armouredsouls/backups/pre_deploy_*.dump 2>/dev/null | tail -1 | cut -f1 || echo "0")
+  if [ "$PRE_COUNT" -gt 0 ]; then
+    PRE_TOTAL=$(du -ch /opt/armouredsouls/backups/pre_deploy_*.dump 2>/dev/null | tail -1 | cut -f1)
+    echo "    ${PRE_COUNT} files, total ${PRE_TOTAL}"
+  else
+    echo "    (none)"
+  fi
+else
+  echo "  (no backups dir)"
+fi
+
+print_header "USER UPLOADS"
+top_under /opt/armouredsouls/backend/uploads 2 10
+
+print_header "POSTGRES (via Docker volumes if present)"
+if command -v docker >/dev/null 2>&1; then
+  docker system df 2>/dev/null || echo "  (docker available but `docker system df` failed)"
+else
+  echo "  (docker not on PATH — Postgres may be running natively)"
+fi
+
+print_header "APT CACHE"
+if [ -d /var/cache/apt ]; then
+  APT_SIZE=$(du -sh /var/cache/apt 2>/dev/null | cut -f1)
+  echo "  /var/cache/apt: ${APT_SIZE}"
+  echo "  (clean with: sudo apt-get clean)"
+fi
+
+print_header "JOURNAL"
+if command -v journalctl >/dev/null 2>&1; then
+  journalctl --disk-usage 2>/dev/null || echo "  (journalctl --disk-usage failed)"
+fi
+
+echo
+echo "===== END OF REPORT ====="
+exit 0

--- a/app/scripts/disk-monitor.sh
+++ b/app/scripts/disk-monitor.sh
@@ -14,18 +14,33 @@
 #   >= 90% — CRITICAL alert
 #   <  80% — Silent exit
 #
+# Cooldown: 60 minutes per severity. While disk sits above a threshold the
+# operator gets one alert per hour, not one every cron tick. The cooldown
+# resets when the disk drops below the threshold so the next cross-back-up
+# alert fires immediately. State is kept in /var/lib/armouredsouls/ (or
+# /tmp as a fallback) — content is the unix timestamp of the last alert.
+#
 # Always exits 0 to avoid cron error emails.
 # ============================================================================
 
 # Load environment if available
 if [ -f /opt/armouredsouls/backend/.env ]; then
   set -a
+  # shellcheck disable=SC1091
   source /opt/armouredsouls/backend/.env
   set +a
 fi
 
 WEBHOOK="${MONITORING_DISCORD_WEBHOOK:-${DISCORD_WEBHOOK_URL:-}}"
 HOSTNAME=$(hostname)
+COOLDOWN_SECONDS="${DISK_ALERT_COOLDOWN_SECONDS:-3600}"
+
+# Cooldown state directory. Prefer /var/lib/armouredsouls (persists across
+# reboots) but fall back to /tmp if it doesn't exist or isn't writable.
+STATE_DIR="/var/lib/armouredsouls"
+if [ ! -d "$STATE_DIR" ] || ! [ -w "$STATE_DIR" ]; then
+  STATE_DIR="/tmp"
+fi
 
 # Get disk usage percentage for root filesystem
 DISK_USAGE=$(df / --output=pcent | tail -1 | tr -d ' %')
@@ -50,10 +65,51 @@ send_alert() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $message"
 }
 
+# Cooldown gate: returns 0 (alert allowed) if no recent alert at this
+# severity, 1 (skip) otherwise. Side-effect: when allowed, writes the
+# current timestamp to the state file so the next call respects cooldown.
+should_alert() {
+  local severity="$1"
+  local state_file="${STATE_DIR}/disk-alert-${severity}.last"
+  local now
+  now=$(date +%s)
+
+  if [ -f "$state_file" ]; then
+    local last
+    last=$(cat "$state_file" 2>/dev/null || echo 0)
+    local elapsed=$((now - last))
+    if [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+      return 1
+    fi
+  fi
+
+  echo "$now" > "$state_file" 2>/dev/null || true
+  return 0
+}
+
+# Clears the cooldown state for a severity, so the *next* breach fires
+# immediately. Called when disk drops below a threshold so the operator
+# gets a clean alert when it climbs back up.
+clear_alert_state() {
+  local severity="$1"
+  rm -f "${STATE_DIR}/disk-alert-${severity}.last" 2>/dev/null || true
+}
+
 if [ "$DISK_USAGE" -ge 90 ]; then
-  send_alert "🚨 Disk usage CRITICAL: ${DISK_USAGE}% used (${AVAIL_HUMAN} free) on ${HOSTNAME}. Immediate action required."
+  if should_alert "critical"; then
+    send_alert "🚨 Disk usage CRITICAL: ${DISK_USAGE}% used (${AVAIL_HUMAN} free) on ${HOSTNAME}. Immediate action required."
+  fi
 elif [ "$DISK_USAGE" -ge 80 ]; then
-  send_alert "⚠️ Disk usage WARNING: ${DISK_USAGE}% used (${AVAIL_HUMAN} free) on ${HOSTNAME}"
+  # Dropped out of critical → reset critical cooldown so the next critical
+  # crossing alerts immediately.
+  clear_alert_state "critical"
+  if should_alert "warning"; then
+    send_alert "⚠️ Disk usage WARNING: ${DISK_USAGE}% used (${AVAIL_HUMAN} free) on ${HOSTNAME}"
+  fi
+else
+  # Below all thresholds — clear both cooldowns so future breaches are fresh.
+  clear_alert_state "critical"
+  clear_alert_state "warning"
 fi
 
 exit 0

--- a/app/scripts/preflight.sh
+++ b/app/scripts/preflight.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Armoured Souls — Deploy Pre-flight Check
+#
+# Runs at the start of every deploy, BEFORE `npm install`. Two jobs:
+#
+#   1. Free up disk space by trimming old pre-deploy dumps and overflow
+#      daily/weekly backups. Mirrors backup.sh's retention logic so we don't
+#      have to wait for the next backup cron to reclaim space.
+#
+#   2. Abort the deploy with a clear error and a Discord alert if disk usage
+#      is still too high after cleanup. Better to fail fast at second 1 than
+#      have npm install hit ENOSPC and time out at minute 10.
+#
+# Why this is its own script (not inline YAML):
+# - Same logic for ACC + prod — having it in two places in deploy.yml drifts.
+# - Shared with the daily backup cron's retention logic.
+# - Easier to test locally and update without touching workflow YAML.
+#
+# Why this isn't part of backup.sh:
+# - backup.sh runs on a cron schedule. preflight.sh runs on demand at deploy.
+# - backup.sh skips when disk is full. preflight.sh _has to_ free disk and
+#   only fails if it couldn't free enough.
+#
+# Tunables (override via env vars):
+# - PRE_DEPLOY_RETAIN: how many pre_deploy_*.dump files to keep (default: 2)
+# - DAILY_RETAIN:      how many daily backups to keep (default: 2)
+# - WEEKLY_RETAIN:     how many weekly backups to keep (default: 0)
+# - CYCLE_LOGS_RETAIN: how many per-cycle CSV logs to keep (default: 30)
+# - CYCLE_LOGS_DIR:    location of cycleLogger.ts output (default: /opt/armouredsouls/backend/cycle_logs)
+# - DISK_HARD_LIMIT:   abort deploy if disk ≥ this percent post-cleanup (default: 90)
+# ============================================================================
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/armouredsouls/backups}"
+PRE_DEPLOY_RETAIN="${PRE_DEPLOY_RETAIN:-2}"
+DAILY_RETAIN="${DAILY_RETAIN:-2}"
+WEEKLY_RETAIN="${WEEKLY_RETAIN:-0}"
+DISK_HARD_LIMIT="${DISK_HARD_LIMIT:-90}"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] preflight: $1"
+}
+
+# --- Monitoring alert helper (best-effort, never blocks) ---
+send_alert() {
+  local message="$1"
+  local webhook="${MONITORING_DISCORD_WEBHOOK:-${DISCORD_WEBHOOK_URL:-}}"
+  if [ -n "$webhook" ]; then
+    curl -s -H "Content-Type: application/json" \
+      -d "{\"content\": \"$message\"}" \
+      "$webhook" > /dev/null 2>&1 || true
+  fi
+}
+
+# --- Load DB env so the alert message can reference the host ---
+if [ -f /opt/armouredsouls/backend/.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source /opt/armouredsouls/backend/.env
+  set +a
+fi
+
+# --- Disk usage helper (portable: works on Linux + BSD/macOS) ---
+# Returns the disk percent for `/` as an integer (no `%` sign).
+# On Linux we'd prefer `df / --output=pcent`, but we keep this form
+# consistent with backup.sh and friendlier to local testing on macOS.
+disk_pct() {
+  df -P / | awk 'NR==2 {print $5}' | tr -d '%'
+}
+
+mkdir -p "${BACKUP_DIR}/daily" "${BACKUP_DIR}/weekly"
+
+DISK_BEFORE=$(disk_pct)
+log "Disk usage before cleanup: ${DISK_BEFORE}%"
+
+# --- 1. Cleanup old pre-deploy dumps -----------------------------------------
+PRE_DEPLOY_COUNT=$(find "${BACKUP_DIR}" -maxdepth 1 -name "pre_deploy_*.dump" -type f | wc -l)
+if [ "${PRE_DEPLOY_COUNT}" -gt "${PRE_DEPLOY_RETAIN}" ]; then
+  DELETE_COUNT=$((PRE_DEPLOY_COUNT - PRE_DEPLOY_RETAIN))
+  find "${BACKUP_DIR}" -maxdepth 1 -name "pre_deploy_*.dump" -type f -printf '%T+ %p\n' \
+    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+    | xargs -r rm -f
+  log "Removed ${DELETE_COUNT} old pre-deploy backup(s) (kept latest ${PRE_DEPLOY_RETAIN})"
+fi
+
+# --- 2. Cleanup overflow daily backups (defensive — backup.sh runs nightly) --
+DAILY_COUNT=$(find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
+if [ "${DAILY_COUNT}" -gt "${DAILY_RETAIN}" ]; then
+  DELETE_COUNT=$((DAILY_COUNT - DAILY_RETAIN))
+  find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
+    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+    | xargs -r rm -f
+  log "Removed ${DELETE_COUNT} overflow daily backup(s) (kept latest ${DAILY_RETAIN})"
+fi
+
+# --- 3. Cleanup overflow weekly backups --------------------------------------
+WEEKLY_COUNT=$(find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
+if [ "${WEEKLY_COUNT}" -gt "${WEEKLY_RETAIN}" ]; then
+  DELETE_COUNT=$((WEEKLY_COUNT - WEEKLY_RETAIN))
+  find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
+    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+    | xargs -r rm -f
+  log "Removed ${DELETE_COUNT} overflow weekly backup(s) (kept latest ${WEEKLY_RETAIN})"
+fi
+
+# --- 4. Cleanup old per-cycle CSV logs ---------------------------------------
+# `cycleLogger.ts` writes one CSV per cycle to `cycle_logs/`. There's no in-app
+# retention, so this directory grows monotonically (one file per hour). Keep
+# the most recent N for forensics; trim the rest.
+CYCLE_LOGS_DIR="${CYCLE_LOGS_DIR:-/opt/armouredsouls/backend/cycle_logs}"
+CYCLE_LOGS_RETAIN="${CYCLE_LOGS_RETAIN:-30}"
+if [ -d "${CYCLE_LOGS_DIR}" ]; then
+  CYCLE_COUNT=$(find "${CYCLE_LOGS_DIR}" -maxdepth 1 -name "cycle*.csv" -type f | wc -l)
+  if [ "${CYCLE_COUNT}" -gt "${CYCLE_LOGS_RETAIN}" ]; then
+    DELETE_COUNT=$((CYCLE_COUNT - CYCLE_LOGS_RETAIN))
+    find "${CYCLE_LOGS_DIR}" -maxdepth 1 -name "cycle*.csv" -type f -printf '%T+ %p\n' \
+      | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+      | xargs -r rm -f
+    log "Removed ${DELETE_COUNT} old cycle log(s) (kept latest ${CYCLE_LOGS_RETAIN})"
+  fi
+fi
+
+# --- 4. Disk hard-limit check -------------------------------------------------
+DISK_AFTER=$(disk_pct)
+DISK_FREE_HUMAN=$(df -h / | awk 'NR==2 {print $4}')
+log "Disk usage after cleanup: ${DISK_AFTER}% (${DISK_FREE_HUMAN} free)"
+
+if [ "${DISK_AFTER}" -ge "${DISK_HARD_LIMIT}" ]; then
+  log "ERROR: Disk usage ${DISK_AFTER}% still ≥ ${DISK_HARD_LIMIT}% threshold after cleanup"
+
+  # Diagnostic: top 10 disk consumers under /opt and /var, and PM2 log size.
+  # Helps us know what to add to the cleanup logic next time. We capture into
+  # a heredoc so the Discord message stays compact (top 5 lines per section).
+  log "--- Top disk consumers (diagnostic) ---"
+  TOP_OPT=$(du -sh /opt/armouredsouls/* 2>/dev/null | sort -hr | head -5 || echo "  (du failed)")
+  TOP_VAR=$(du -sh /var/log/* 2>/dev/null | sort -hr | head -5 || echo "  (du failed)")
+  PM2_LOGS=$(du -sh "$HOME/.pm2/logs" 2>/dev/null || echo "  (no pm2 logs dir)")
+  CYCLE_LOGS=$(du -sh /opt/armouredsouls/backend/cycle_logs 2>/dev/null || echo "  (no cycle_logs)")
+
+  echo "${TOP_OPT}"
+  echo "${TOP_VAR}"
+  echo "PM2:        ${PM2_LOGS}"
+  echo "cycle_logs: ${CYCLE_LOGS}"
+
+  # Compose Discord alert with the diagnostic summary inline so we don't have
+  # to SSH in to investigate. Discord truncates over 2000 chars; we aim for ~1500.
+  ALERT_BODY=$(printf '%s' \
+"🚨 Deploy ABORTED on $(hostname): disk ${DISK_AFTER}% (${DISK_FREE_HUMAN} free) ≥ ${DISK_HARD_LIMIT}% after cleanup.
+
+Top consumers:
+**/opt/armouredsouls/**
+\`\`\`
+${TOP_OPT}
+\`\`\`
+**/var/log/**
+\`\`\`
+${TOP_VAR}
+\`\`\`
+PM2 logs: ${PM2_LOGS}
+cycle_logs: ${CYCLE_LOGS}
+
+Investigate before retrying.")
+  send_alert "${ALERT_BODY}"
+  exit 1
+fi
+
+log "Pre-flight check passed"


### PR DESCRIPTION
## Summary

ACC deploy on 25 May timed out at 10 minutes during `npm install --prefer-offline` because the VPS was at 87% disk and `npm install` + a fresh pre-deploy DB dump didn't fit. The site recovered on its own once the next backup cron freed space (UptimeRobot saw it down for ~21 min). The cron-based disk monitor was also spamming Discord every ~15 min while disk sat above 80%.

This PR addresses the symptoms — deploy timeouts, alert spam, and missing diagnostic visibility — but **does not fix the root cause**, which is a 5.3 GB Postgres Docker volume on a 20 GB DEV1-S. That deserves its own data-retention spec (will write up separately based on the table-size investigation).

3 commits, all in `app/scripts/` + a single `deploy.yml` change.

## What's in here

### Commit 1 — `app/scripts/preflight.sh` + deploy.yml integration

New step that runs on every deploy BEFORE `npm install`:

- Trims old `pre_deploy_*.dump` files (keep last 2)
- Trims overflow daily/weekly backups (mirrors `backup.sh` retention)
- Trims `cycle_logs/cycleN.csv` over the last 30 (cycleLogger never had retention; one CSV per hour)
- Aborts the deploy with a Discord alert if disk is still ≥ 90% post-cleanup. Alert includes a diagnostic dump of top consumers under `/opt`, `/var/log`, PM2 logs, and `cycle_logs/` so we don't have to SSH in to investigate

Wired into both ACC and production blocks of `deploy.yml` with a 2-minute SSH timeout.

### Commit 2 — `disk-monitor.sh` cooldown + new `disk-diagnostic.sh`

`disk-monitor.sh` was firing every 15 min (every cron tick) while disk was above threshold — no cooldown. Added persistent cooldown state at `/var/lib/armouredsouls/disk-alert-{warning,critical}.last` (falls back to `/tmp`). Default 1 hour per severity, tunable via `DISK_ALERT_COOLDOWN_SECONDS`. State auto-clears when disk drops below threshold so the next cross-back-up alert fires immediately.

New `disk-diagnostic.sh` for on-demand investigation. Reports top consumers under `/opt/armouredsouls`, `/var/log`, PM2 logs, cycle_logs, backups (split by category), uploads, Docker volumes, APT cache, and journald.

### Commit 3 — diagnostic script reads Postgres user/db from .env

Hit during real investigation. ACC uses `POSTGRES_USER=as_acc`, prod uses `as_prd` — the local docker-compose's `armouredsouls` doesn't apply. Read credentials from `/opt/armouredsouls/backend/.env` instead. Also expanded the Postgres section to run the actual table-size + dead-tuple queries plus report `pg_wal` size separately (WAL bloat is a different failure mode than table bloat).

## Verification

- `bash -n` passes on all three scripts
- YAML validates (`pyyaml.safe_load`)
- Logic mirrors `backup.sh` patterns line-for-line where they overlap (find printf sort head xargs)

The first real test is at deploy time. If the script has a bug it surfaces there with a Discord alert showing what happened, not a 10-minute hang.

## What's NOT in this PR

Per discussion in the conversation:

- **No `npm install` changes** (3bc9c97 / f7bb156 / 1e8944a / 1c678fa cycle confirms previous attempts didn't work; out of scope)
- **No application-level cycle-log retention** (riskier; cleanup at deploy time is sufficient for this incident)
- **No Postgres data-retention work** (separate spec — preliminary disk diagnostic from prod showed Postgres volume is 5.3 GB / 27% of disk; needs its own design)

## Draft because

Site is currently running. Don't want to merge → auto-deploy until we've separately verified disk via the diagnostic script run manually on the VPS, and confirmed the Postgres volume situation isn't going to push us over 90% during the deploy itself.

Open the draft to read; don't merge until disk has been triaged manually.
