### PR TITLE
fix(deploy): stop sourcing .env in preflight (crashes on parse)

### DIFF
--- a/app/scripts/preflight.sh
+++ b/app/scripts/preflight.sh
@@ -44,6 +44,13 @@ log() {
 }
 
 # --- Monitoring alert helper (best-effort, never blocks) ---
+# We rely on MONITORING_DISCORD_WEBHOOK / DISCORD_WEBHOOK_URL being present
+# in the inherited environment if a Discord alert is wanted. We deliberately
+# do NOT `source /opt/armouredsouls/backend/.env` — sourcing crashes under
+# `set -e` whenever a value contains shell-special characters (the
+# 25 May ACC deploy failed at "line 7: 20: command not found"). If the
+# webhook env vars aren't present the alert is a no-op and the script's
+# exit code still drives the deploy success/failure decision.
 send_alert() {
   local message="$1"
   local webhook="${MONITORING_DISCORD_WEBHOOK:-${DISCORD_WEBHOOK_URL:-}}"
@@ -53,14 +60,6 @@ send_alert() {
       "$webhook" > /dev/null 2>&1 || true
   fi
 }
-
-# --- Load DB env so the alert message can reference the host ---
-if [ -f /opt/armouredsouls/backend/.env ]; then
-  set -a
-  # shellcheck disable=SC1091
-  source /opt/armouredsouls/backend/.env
-  set +a
-fi
 
 # --- Disk usage helper (portable: works on Linux + BSD/macOS) ---
 # Returns the disk percent for `/` as an integer (no `%` sign).


### PR DESCRIPTION
Fixes the failing 25 May ACC deploy:

```
/opt/armouredsouls/backend/.env: line 7: 20: command not found
2026/05/25 13:24:36 Process exited with status 127
```

`preflight.sh` was doing `set -a; source /opt/armouredsouls/backend/.env; set +a` to pull webhook URLs out of the env file. Sourcing crashes under `set -e` whenever a .env line contains shell-special characters bash can't parse cleanly — exactly what was happening on line 7.

The preflight only needed those vars for an optional Discord alert. Removed the source block entirely. `send_alert` already gracefully no-ops when the webhook URLs aren't set. The deploy workflow's existing `Notify failure` step covers Discord alerting on overall deploy failure regardless.

## Diff

8 lines deleted, 7 lines of comment added explaining why.

## Verification

- `bash -n` clean
- The actual production-side test happens at deploy time. If preflight passes, install goes ahead.

## Why this is small and not the kitchen-sink fix

`backup.sh` and `disk-monitor.sh` use the same pattern. They could break the same way at any point. They're not breaking *now*, so they're out of scope for this hotfix. We can address them in a follow-up.
