### PR TITLE
ci(security-audit): cache npm and skip postinstall scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,14 +309,21 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: |
+            app/backend/package-lock.json
+            app/frontend/package-lock.json
 
+      # npm audit only reads package-lock.json, so we skip postinstall scripts
+      # to avoid transient CDN timeouts from native-binary downloads
+      # (e.g., onnxruntime-node via gitnexus → @huggingface/transformers).
       - name: Install backend dependencies
         working-directory: ./app/backend
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install frontend dependencies
         working-directory: ./app/frontend
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate audit report (backend)
         working-directory: ./app/backend


### PR DESCRIPTION
## Problem

The **Security Audit** job has been failing intermittently with:

```
npm error path .../node_modules/@huggingface/transformers/node_modules/onnxruntime-node
npm error AggregateError [ETIMEDOUT]
npm error     Error: connect ETIMEDOUT 150.171.109.77:443
```

Latest occurrence: [run 26403605172](https://github.com/RobertTeunissen/ArmouredSouls/actions/runs/26403605172).

### Root cause

The `setup-node` step in the Security Audit job was missing `cache: 'npm'` (unlike the other jobs that share the same lockfiles). With no cache, every run does a full cold `npm ci`, which triggers `onnxruntime-node`'s postinstall script (pulled in transitively via `gitnexus` → `@huggingface/transformers`). That script downloads ~100 MB of native binaries from a third-party CDN, and a transient network blip surfaces as a hard CI failure.

## Fix

1. Add `cache: 'npm'` to the job's `setup-node`, with both backend and frontend lockfiles, matching the other jobs.
2. Pass `--ignore-scripts` to `npm ci`. `npm audit` only reads `package-lock.json`, so postinstall side effects are unnecessary here. This cuts install time and removes the CDN dependency entirely from the audit path.

## What was tested

- Diff is 9 additions, 2 deletions, isolated to `.github/workflows/ci.yml`.
- The Security Audit job in this PR will exercise the change.

## Blocked features

None.
