### PR TITLE
fix(deploy): use npm ci on the VPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -432,14 +432,17 @@ jobs:
           username: ${{ secrets.ACC_VPS_USER }}
           key: ${{ secrets.ACC_SSH_KEY }}
           command_timeout: 10m
-          # NODE_ENV=production: tells patch-package to skip dev-only patches.
-          # --omit=dev: skips devDependencies (jest, eslint, gitnexus, etc.)
-          # so we don't pull ~226 MB of @huggingface/transformers and
-          # onnxruntime-node native binaries on every deploy. Cuts the install
-          # tree from ~1.7 GB to the ~500 production packages we actually need.
+          # `npm ci` (not `npm install`) so `--omit=dev` is honored even when
+          # an old node_modules is on disk from a previous deploy. With
+          # `npm install` we observed it report "added 893 packages" — the
+          # full dev tree — while reporting success, leaving things in an
+          # inconsistent state that broke the seed step. `npm ci` wipes
+          # node_modules, reinstalls deterministically from the lockfile, and
+          # respects --omit=dev. NODE_ENV=production also tells patch-package
+          # to skip dev-only patches (gitnexus+1.6.5.dev.patch).
           script: |
             cd /opt/armouredsouls/backend
-            NODE_ENV=production npm install --omit=dev --prefer-offline --no-audit --no-fund
+            NODE_ENV=production npm ci --omit=dev --prefer-offline --no-audit --no-fund
             npx prisma generate
 
       - name: Create pre-migration database backup
@@ -745,14 +748,10 @@ jobs:
           username: ${{ secrets.PRD_VPS_USER }}
           key: ${{ secrets.PRD_SSH_KEY }}
           command_timeout: 10m
-          # NODE_ENV=production: tells patch-package to skip dev-only patches.
-          # --omit=dev: skips devDependencies (jest, eslint, gitnexus, etc.)
-          # so we don't pull ~226 MB of @huggingface/transformers and
-          # onnxruntime-node native binaries on every deploy. Cuts the install
-          # tree from ~1.7 GB to the ~500 production packages we actually need.
+          # See the deploy-acc job for why this is `npm ci` not `npm install`.
           script: |
             cd /opt/armouredsouls/backend
-            NODE_ENV=production npm install --omit=dev --prefer-offline --no-audit --no-fund
+            NODE_ENV=production npm ci --omit=dev --prefer-offline --no-audit --no-fund
             npx prisma generate
 
       - name: Create pre-migration database backup


### PR DESCRIPTION
## Problem

After PR #334 the deploy got past install but failed on seed:

```
Running seed command `tsx prisma/seed.ts` ...
Error: Command failed with ENOENT: tsx prisma/seed.ts
spawn tsx ENOENT
```

The install log shows `added 893 packages` — that's the **full devDependency tree**, not the ~356-package production tree we expected. So `--omit=dev` had no effect.

### Root cause

`npm install --omit=dev` against an existing `node_modules` from a previous deploy is not deterministic. With `tsx` having just moved from `devDependencies` to `dependencies` in #334, `npm install` reconciled against the new package.json, decided the existing tree (reset by the previous `npm prune --production`) needed to be re-expanded, but ended up in an inconsistent state where `node_modules/.bin/tsx` was missing.

This worked before #328 because the workflow ran `npm install --prefer-offline` (which always installs the **full** tree, devDeps included) and then a separate `npm prune --production` step. The seed ran in between, when the full tree was on disk and `tsx` was guaranteed to be there.

#334 collapsed that into a single `npm install --omit=dev` for speed and disk savings, but lost the determinism guarantee.

## Fix

Switch the VPS install from `npm install --omit=dev` to `npm ci --omit=dev`. `npm ci`:

- Wipes `node_modules` and reinstalls exactly from `package-lock.json`
- Honors `--omit=dev` unconditionally
- Never rewrites the lockfile
- Is what `npm ci` is for in deploy environments

Applied in both `deploy-acc` and `deploy-prd`.

## What was tested

Replayed the exact deploy install path locally:

```
NODE_ENV=production npm ci --omit=dev --prefer-offline --no-audit --no-fund
```

Output:

```
> patch-package && prisma generate
patch-package 8.0.1
Applying patches...
Skipping dev-only gitnexus@1.6.5 ✔
✔ Generated Prisma Client (v7.8.0) to ./generated/prisma in 141ms
added 356 packages in 6s
```

Verified:
- 356 packages, not 893 — `--omit=dev` correctly applied
- `node_modules/.bin/tsx` present (as a regular dep)
- `node_modules/.bin/prisma` present (as a regular dep)
- patch-package skips the dev-only gitnexus patch
- prisma generate succeeds

## Blocked features

None. Local dev unchanged.

Refs: failing run https://github.com/RobertTeunissen/ArmouredSouls/actions/runs/26406298646
