### PR TITLE
fix(backup): safe .env parsing + cleanup before disk guard

### DIFF
--- a/app/scripts/backup.sh
+++ b/app/scripts/backup.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # ============================================================================
 # Armoured Souls — Daily PostgreSQL Backup
-# Configurable retention (defaults: 3 daily + 2 weekly)
-# Skips backup if disk usage exceeds threshold to prevent ENOSPC outages
+# Configurable retention via env vars (defaults: 2 daily + 0 weekly).
+# Old backups are cleaned BEFORE the disk-full guard so the script can
+# self-recover when disk usage is already above the threshold.
 # ============================================================================
 
 BACKUP_DIR="/opt/armouredsouls/backups"
@@ -15,17 +16,32 @@ WEEKLY_RETAIN="${BACKUP_WEEKLY_RETAIN:-0}"
 PRE_DEPLOY_RETAIN="${BACKUP_PRE_DEPLOY_RETAIN:-2}"
 DISK_THRESHOLD="${BACKUP_DISK_THRESHOLD:-85}"
 
-# Load database credentials from environment or .env file
-if [ -f /opt/armouredsouls/backend/.env ]; then
-  set -a
-  source /opt/armouredsouls/backend/.env
-  set +a
-fi
+# Read a single key from the .env file as plain text. Avoids `source .env`
+# entirely — bash's `source` interprets unquoted values as commands, e.g.
+# `LEAGUE_SCHEDULE=0 20 * * *` makes it try to run `20` and crashes the
+# script with "20: command not found". This helper instead grabs the last
+# line matching `KEY=`, strips the `KEY=` prefix and surrounding quotes,
+# and returns the raw value. Same fix shape as preflight.sh (PR #332).
+env_get() {
+  local key="$1"
+  local file="$2"
+  [ -f "$file" ] || return 0
+  grep -E "^${key}=" "$file" | tail -n 1 | cut -d= -f2- | sed -E 's/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/'
+}
 
-DB_USER="${POSTGRES_USER:-armouredsouls}"
-DB_NAME="${POSTGRES_DB:-armouredsouls}"
-DB_HOST="${POSTGRES_HOST:-127.0.0.1}"
-DB_PORT="${POSTGRES_PORT:-5432}"
+ENV_FILE="/opt/armouredsouls/backend/.env"
+DB_USER="${POSTGRES_USER:-$(env_get POSTGRES_USER "$ENV_FILE")}"
+DB_NAME="${POSTGRES_DB:-$(env_get POSTGRES_DB "$ENV_FILE")}"
+DB_HOST="${POSTGRES_HOST:-$(env_get POSTGRES_HOST "$ENV_FILE")}"
+DB_PORT="${POSTGRES_PORT:-$(env_get POSTGRES_PORT "$ENV_FILE")}"
+MONITORING_DISCORD_WEBHOOK="${MONITORING_DISCORD_WEBHOOK:-$(env_get MONITORING_DISCORD_WEBHOOK "$ENV_FILE")}"
+DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-$(env_get DISCORD_WEBHOOK_URL "$ENV_FILE")}"
+
+# Apply defaults after env resolution
+DB_USER="${DB_USER:-armouredsouls}"
+DB_NAME="${DB_NAME:-armouredsouls}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-5432}"
 
 mkdir -p "${BACKUP_DIR}/daily" "${BACKUP_DIR}/weekly"
 
@@ -56,6 +72,30 @@ if [ "${PRE_DEPLOY_COUNT}" -gt "${PRE_DEPLOY_RETAIN}" ]; then
   log "Cleaned up ${DELETE_COUNT} old pre-deploy backup(s)"
 fi
 
+# --- Cleanup old daily backups (also runs BEFORE the disk guard) ---
+# Without this, a single day above the disk threshold causes the script to
+# bail out before the cleanup step at the bottom, leaving old backups on
+# disk forever and making the disk-full state self-reinforcing. We saw this
+# happen on ACC: backups stopped at May 18 with 3.1 GB of files locked up.
+DAILY_COUNT=$(find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
+if [ "${DAILY_COUNT}" -gt "${DAILY_RETAIN}" ]; then
+  DELETE_COUNT=$((DAILY_COUNT - DAILY_RETAIN))
+  find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
+    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+    | xargs rm -f
+  log "Cleaned up ${DELETE_COUNT} old daily backup(s)"
+fi
+
+# --- Cleanup old weekly backups (also runs BEFORE the disk guard) ---
+WEEKLY_COUNT=$(find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
+if [ "${WEEKLY_COUNT}" -gt "${WEEKLY_RETAIN}" ]; then
+  DELETE_COUNT=$((WEEKLY_COUNT - WEEKLY_RETAIN))
+  find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
+    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
+    | xargs rm -f
+  log "Cleaned up ${DELETE_COUNT} old weekly backup(s)"
+fi
+
 # --- Disk space guard ---
 DISK_USAGE=$(df / --output=pcent | tail -1 | tr -d ' %')
 if [ "${DISK_USAGE}" -ge "${DISK_THRESHOLD}" ]; then
@@ -82,26 +122,6 @@ if [ "${DAY_OF_WEEK}" -eq 7 ]; then
   WEEKLY_FILE="${BACKUP_DIR}/weekly/${DB_NAME}_weekly_${TIMESTAMP}.dump"
   cp "${DAILY_FILE}" "${WEEKLY_FILE}"
   log "Weekly backup created: ${WEEKLY_FILE}"
-fi
-
-# --- Cleanup old daily backups (keep last N) ---
-DAILY_COUNT=$(find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
-if [ "${DAILY_COUNT}" -gt "${DAILY_RETAIN}" ]; then
-  DELETE_COUNT=$((DAILY_COUNT - DAILY_RETAIN))
-  find "${BACKUP_DIR}/daily" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
-    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
-    | xargs rm -f
-  log "Cleaned up ${DELETE_COUNT} old daily backup(s)"
-fi
-
-# --- Cleanup old weekly backups (keep last N) ---
-WEEKLY_COUNT=$(find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f | wc -l)
-if [ "${WEEKLY_COUNT}" -gt "${WEEKLY_RETAIN}" ]; then
-  DELETE_COUNT=$((WEEKLY_COUNT - WEEKLY_RETAIN))
-  find "${BACKUP_DIR}/weekly" \( -name "*.dump" -o -name "*.sql.gz" \) -type f -printf '%T+ %p\n' \
-    | sort | head -n "${DELETE_COUNT}" | awk '{print $2}' \
-    | xargs rm -f
-  log "Cleaned up ${DELETE_COUNT} old weekly backup(s)"
 fi
 
 log "Backup process complete"


### PR DESCRIPTION
Two coupled bugs in backup.sh, both surfaced today on ACC.

## 1. `source .env` crash

Same shape as the preflight.sh bug fixed in PR #332. With

    LEAGUE_SCHEDULE=0 20 * * *

in the .env file, `source` parses the assignment as `LEAGUE_SCHEDULE=0` and tries to execute `20 * * *` as a command. Bash exits non-zero with

    /opt/armouredsouls/backend/.env: line 7: 20: command not found

This time the script can't just drop the env load — it actually needs POSTGRES_USER / POSTGRES_DB / POSTGRES_HOST / POSTGRES_PORT plus the Discord webhook URL. Replaces `source` with a small `env_get` helper that reads each key as plain text via grep+cut+sed, never letting the shell evaluate values. Verified against a synthetic .env with plain values, quoted values, values containing spaces, cron strings, and missing keys.

## 2. Cleanup ran AFTER the disk guard

The flow was:

  1. cleanup pre_deploy/* (before disk guard — already correct)
  2. disk guard — exit 0 if disk >= 85%
  3. pg_dump
  4. cleanup daily/* and weekly/*  ← never reached when disk full

So once the disk crossed 85%, the script bailed out, leaving old backups on disk forever. Self-reinforcing: the more disk fills up, the more old backups stay around to keep it filled. We saw this on ACC: backups stopped at May 18, leaving 3.1 GB of dump files unable to be cleaned by the script itself.

Moves the daily/weekly cleanup blocks before the disk guard, same shape as the existing pre_deploy cleanup. The script can now self-recover from a disk-full state on the next scheduled run.

## Cleanup of stale comment

Header said "defaults: 3 daily + 2 weekly" but actual defaults are 2 daily + 0 weekly. Updated to match.