### PR TITLE
fix: seed only subscribes test_user_ robots with cap check

### DIFF
--- a/app/backend/prisma/seed.ts
+++ b/app/backend/prisma/seed.ts
@@ -1108,26 +1108,42 @@ async function seedWimpBotUsers(weapons: { id: number; name: string }[]) {
 async function seedTeamTournaments(_weapons: { id: number; name: string }[]) {
   console.log('Creating team tournament seed data...');
 
-  // Helper: ensure subscription exists for a robot
-  async function ensureSubscription(robotId: number, eventType: string): Promise<void> {
-    await prisma.subscription.upsert({
+  // Helper: ensure subscription exists for a robot, respecting Booking Office cap
+  // Pre-fetch cap data for all test users to avoid N+1 queries
+  const testUserFacilities = await prisma.facility.findMany({
+    where: { facilityType: 'booking_office', user: { username: { startsWith: 'test_user_' } } },
+    select: { userId: true, level: true },
+  });
+  const facilityLevelMap = new Map(testUserFacilities.map(f => [f.userId, f.level]));
+
+  async function ensureSubscription(robotId: number, robotUserId: number, eventType: string): Promise<void> {
+    const existing = await prisma.subscription.findUnique({
       where: { subscription_robot_event: { robotId, eventType } },
-      update: {},
-      create: { robotId, eventType, status: 'active' },
+    });
+    if (existing) return;
+
+    const { getSubscriptionCap } = await import('../src/config/subscriptions');
+    const level = facilityLevelMap.get(robotUserId) ?? 0;
+    const cap = getSubscriptionCap(level);
+    const currentCount = await prisma.subscription.count({ where: { robotId } });
+    if (currentCount >= cap) return;
+
+    await prisma.subscription.create({
+      data: { robotId, eventType, status: 'active' },
     });
   }
 
-  // Step 1: Find existing teams and subscribe their members
+  // Step 1: Find existing teams owned by generated users and subscribe their members
   const existing2v2Teams = await prisma.teamBattle.findMany({
-    where: { teamSize: 2, eligibility: 'ELIGIBLE' },
-    include: { members: { select: { robotId: true } } },
+    where: { teamSize: 2, eligibility: 'ELIGIBLE', stable: { username: { startsWith: 'test_user_' } } },
+    include: { members: { select: { robotId: true, robot: { select: { userId: true } } } } },
     take: 8,
     orderBy: { createdAt: 'asc' },
   });
 
   const existing3v3Teams = await prisma.teamBattle.findMany({
-    where: { teamSize: 3, eligibility: 'ELIGIBLE' },
-    include: { members: { select: { robotId: true } } },
+    where: { teamSize: 3, eligibility: 'ELIGIBLE', stable: { username: { startsWith: 'test_user_' } } },
+    include: { members: { select: { robotId: true, robot: { select: { userId: true } } } } },
     take: 8,
     orderBy: { createdAt: 'asc' },
   });
@@ -1137,15 +1153,15 @@ async function seedTeamTournaments(_weapons: { id: number; name: string }[]) {
     return;
   }
 
-  // Subscribe all member robots to tournament events
+  // Subscribe all member robots to tournament events (only if they have cap room)
   for (const team of existing2v2Teams) {
     for (const member of team.members) {
-      await ensureSubscription(member.robotId, 'tournament_2v2');
+      await ensureSubscription(member.robotId, member.robot.userId, 'tournament_2v2');
     }
   }
   for (const team of existing3v3Teams) {
     for (const member of team.members) {
-      await ensureSubscription(member.robotId, 'tournament_3v3');
+      await ensureSubscription(member.robotId, member.robot.userId, 'tournament_3v3');
     }
   }
 

--- a/app/backend/src/services/analytics/matchmakingService.ts
+++ b/app/backend/src/services/analytics/matchmakingService.ts
@@ -5,10 +5,6 @@ import logger from '../../config/logger';
 import {
   calculateMatchScore,
   MatchScoreInput,
-  LP_MATCH_IDEAL,
-  LP_MATCH_FALLBACK,
-  ELO_MATCH_IDEAL,
-  ELO_MATCH_FALLBACK,
   RECENT_OPPONENT_LIMIT,
 } from '../matchmaking/teamMatchmakingUtils';
 

--- a/app/backend/src/services/team-battle/teamBattleService.ts
+++ b/app/backend/src/services/team-battle/teamBattleService.ts
@@ -95,7 +95,7 @@ export async function registerTeam(
   robotIds: number[],
   teamName: string,
   teamSize: 2 | 3,
-  userId: number,
+  _userId: number,
 ): Promise<TeamBattle> {
   // Validate team size
   if (!VALID_TEAM_SIZES.includes(teamSize)) {

--- a/app/backend/src/services/tournament/teamTournamentBattleOrchestrator.ts
+++ b/app/backend/src/services/tournament/teamTournamentBattleOrchestrator.ts
@@ -399,7 +399,7 @@ export async function processTeamTournamentBattle(
  */
 export async function executeTeamTournamentRound(
   tournamentId: number,
-  teamSize: 2 | 3,
+  _teamSize: 2 | 3,
 ): Promise<RoundExecutionResult> {
   // 1. Load tournament
   const tournament = await prisma.tournament.findUnique({

--- a/app/backend/src/services/tournament/tournamentService.ts
+++ b/app/backend/src/services/tournament/tournamentService.ts
@@ -399,8 +399,10 @@ export async function createTournament(options: CreateTournamentOptions): Promis
  * - Top half of bracket: Seeds 1, 8, 5, 4, 3, 6, 7, 2 (for 8-slot)
  * - Seeds are distributed to ensure top seeds only meet in later rounds
  * - Sequential winner advancement maintains bracket structure
+ *
+ * @deprecated Superseded by generateBracketPairsGeneric — retained for reference.
  */
-function generateBracketPairs(seededRobots: Robot[], maxRounds: number): ScheduledTournamentMatch[] {
+function _generateBracketPairs(seededRobots: Robot[], maxRounds: number): ScheduledTournamentMatch[] {
   const matches: ScheduledTournamentMatch[] = [];
   const bracketSize = Math.pow(2, maxRounds); // Next power of 2
   

--- a/app/frontend/src/components/ActiveTournamentCard.tsx
+++ b/app/frontend/src/components/ActiveTournamentCard.tsx
@@ -7,7 +7,7 @@
  * Requirements: R9.18, R9.19
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../utils/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -45,11 +45,7 @@ function ActiveTournamentCard() {
   const [error, setError] = useState<string | null>(null);
   const { user } = useAuth();
 
-  useEffect(() => {
-    fetchActiveTournaments();
-  }, []);
-
-  const fetchActiveTournaments = async () => {
+  const fetchActiveTournaments = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -98,7 +94,11 @@ function ActiveTournamentCard() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.id]);
+
+  useEffect(() => {
+    fetchActiveTournaments();
+  }, [fetchActiveTournaments]);
 
   if (error) {
     return (

--- a/app/frontend/src/components/tournament/BracketView.tsx
+++ b/app/frontend/src/components/tournament/BracketView.tsx
@@ -31,7 +31,10 @@ const BracketView: React.FC<BracketViewProps> = ({
   const [endRound, setEndRound] = useState(maxRounds);
 
   // Support legacy userRobotIds prop for backward compatibility
-  const effectiveUserParticipantIds = userParticipantIds ?? userRobotIds ?? new Set<number>();
+  const effectiveUserParticipantIds = useMemo(
+    () => userParticipantIds ?? userRobotIds ?? new Set<number>(),
+    [userParticipantIds, userRobotIds],
+  );
 
   const isTeamTournament = participantType === 'team_2v2' || participantType === 'team_3v3';
 


### PR DESCRIPTION
- Filter team tournament seed to only test_user_* owned teams
- Add cap check before subscribing (respects Booking Office level)
- Remove fix-tournament-subscriptions.ts script (one-time SQL is sufficient)
- Include robot.userId in team member query for efficient cap lookup